### PR TITLE
feature: support self hosted vcs

### DIFF
--- a/bootstrap/azuredevops/variables.tf
+++ b/bootstrap/azuredevops/variables.tf
@@ -45,7 +45,7 @@ variable "postfix_number" {
 }
 
 variable "azure_devops_use_organisation_legacy_url" {
-  description = "Use the legacy Azure DevOps URL (<organisation>.visualstudio.com) instead of the new URL (dev.azure.com/<organization>). This is ignored if an fqdn is supplied for version_control_system_organization|8|bool"
+  description = "Use the legacy Azure DevOps URL (<organisation>.visualstudio.com) instead of the new URL (dev.azure.com/<organization>). This is ignored if an fqdn is supplied for version_control_system_organization|9|bool"
   type        = bool
   default     = false
 }

--- a/bootstrap/azuredevops/variables.tf
+++ b/bootstrap/azuredevops/variables.tf
@@ -11,7 +11,7 @@ variable "version_control_system_access_token" {
 }
 
 variable "version_control_system_organization" {
-  description = "The organization for the version control system to use for the deployment|3"
+  description = "The organization for the version control system to use for the deployment (supply a fqdn e.g. https://vcs.company.com/my-org to use a self-hosted Azure DevOps Server)|3"
   type        = string
 }
 
@@ -39,7 +39,7 @@ variable "postfix_number" {
 }
 
 variable "azure_devops_use_organisation_legacy_url" {
-  description = "Use the legacy Azure DevOps URL (<organisation>.visualstudio.com) instead of the new URL (dev.azure.com/<organization>)|8|bool"
+  description = "Use the legacy Azure DevOps URL (<organisation>.visualstudio.com) instead of the new URL (dev.azure.com/<organization>). This is ignored if an fqdn is supplied for version_control_system_organization|8|bool"
   type        = bool
   default     = false
 }

--- a/bootstrap/github/variables.tf
+++ b/bootstrap/github/variables.tf
@@ -11,7 +11,7 @@ variable "version_control_system_access_token" {
 }
 
 variable "version_control_system_organization" {
-  description = "The organization for the version control system to use for the deployment|3"
+  description = "The organization for the version control system to use for the deployment (supply a fqdn e.g. https://vcs.company.com/my-org to use a self-hosted GitHub Enterprise Server)|3"
   type        = string
 }
 

--- a/bootstrap/modules/azure_devops/locals.tf
+++ b/bootstrap/modules/azure_devops/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  organization_url = var.use_legacy_organization_url ? "https://${var.organization_name}.visualstudio.com" : "https://dev.azure.com/${var.organization_name}"
+  organization_url = startswith(lower(var.organization_name), "https://") || startswith(lower(var.organization_name), "http://") ? var.organization_name : (var.use_legacy_organization_url ? "https://${var.organization_name}.visualstudio.com" : "https://dev.azure.com/${var.organization_name}")
 }
 
 locals {

--- a/bootstrap/modules/github/locals.tf
+++ b/bootstrap/modules/github/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  organization_url = "https://github.com/${var.organization_name}"
+  organization_url = startswith(lower(var.organization_name), "https://") || startswith(lower(var.organization_name), "http://") ? var.organization_name :  "https://github.com/${var.organization_name}"
 }

--- a/bootstrap/modules/github/locals.tf
+++ b/bootstrap/modules/github/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  organization_url = startswith(lower(var.organization_name), "https://") || startswith(lower(var.organization_name), "http://") ? var.organization_name :  "https://github.com/${var.organization_name}"
+  organization_url = startswith(lower(var.organization_name), "https://") || startswith(lower(var.organization_name), "http://") ? var.organization_name : "https://github.com/${var.organization_name}"
 }

--- a/docs/wiki/[User-Guide]-Quick-Start-Phase-2.md
+++ b/docs/wiki/[User-Guide]-Quick-Start-Phase-2.md
@@ -19,12 +19,12 @@ The inputs differ depending on the VCS you have chosen:
 1. Fill out the following inputs:
     1. `starter_module`: This is the choice of [Starter Modules][wiki_starter_modules], which is the baseline configuration you want for your Azure landing zone. This also determine the second set of input you'll be prompted for here.
     1. `version_control_system_access_token`: Enter the Azure DevOps PAT you generated in a previous step.
-    1. `version_control_system_organization`: Enter the name of your Azure DevOps organization.
+    1. `version_control_system_organization`: Enter the name of your Azure DevOps organization. If you are using a self-hosted Azure DevOps Server, supply the fqdn, e.g. `https://vcs.company.com/my-org`.
     1. `azure_location`: Enter the Azure region where you would like to deploy the storage account and identity for your continuous delivery pipeline. This field expects the `name` of the region, such as `uksouth`. You can find a full list of names by running `az account list-locations -o table`.
     1. `service_name`: This is used to build up the names of your Azure and Azure DevOps resources, for example `rg-<service_name>-mgmt-uksouth-001`. We recommend using `alz` for this.
     1. `environment_name`: This is used to build up the names of your Azure and Azure DevOps resources, for example `rg-alz-<environment_name>-uksouth-001`. We recommend using `mgmt` for this.
     1. `postfix_number`: This is used to build up the names of your Azure and Azure DevOps resources, for example `rg-alz-mgmt-uksouth-<postfix_number>`. We recommend using `1` for this.
-    1. `azure_devops_use_organisation_legacy_url`: If you have not migrated to the modern url (still using `https://<organization_name>.visualstudio.com`) for your Azure DevOps organisation, then set this to `true`.
+    1. `azure_devops_use_organisation_legacy_url`: If you have not migrated to the modern url (still using `https://<organization_name>.visualstudio.com`) for your Azure DevOps organisation, then set this to `true`. This is ignored if you supply an fqdn to `version_control_system_organization`.
     1. `azure_devops_create_project`: If you have an existing project you want to use rather than creating a new one, select `true`. We recommend creating a new project to ensure it is isolated by a strong security boundary.
     1. `azure_devops_project_name`: Enter the name of the Azure DevOps project to create or the name of an existing poroject if you set `azure_devops_create_project` to `false`.
     1. `azure_devops_authentication_scheme`: Enter the authentication scheme that your pipeline will use to authenticate to Azure. `WorkloadIdentityFederation` uses OpenId Connect and is the recommended approach. `ManagedServiceIdentity` requires the deployment of self-hosted agents are part of the bootstrap setup.
@@ -44,7 +44,7 @@ The inputs differ depending on the VCS you have chosen:
 1. Fill out the following inputs:
     1. `starter_module`: This is the choice of [Starter Module][wiki_starter_modules], which is the baseline configuration you want for your Azure landing zone. This also determine the second set of input you'll be prompted for here.
     1. `version_control_system_access_token`: Enter the GitHub PAT you generated in a previous step.
-    1. `version_control_system_organization`: Enter the name of your GitHub organization.
+    1. `version_control_system_organization`: Enter the name of your GitHub organization. If you are using a self-hosted GitHub Enterprise Server, supply the fqdn, e.g. `https://vcs.company.com/my-org`.
     1. `azure_location`: Enter the Azure region where you would like to deploy the storage account and identity for your continuous delivery pipeline. This field expects the `name` of the region, such as `uksouth`. You can find a full list of names by running `az account list-locations -o table`.
     1. `service_name`: This is used to build up the names of your Azure and GitHub resources, for example `rg-<service_name>-mgmt-uksouth-001`. We recommend using `alz` for this.
     1. `environment_name`: This is used to build up the names of your Azure and GitHub resources, for example `rg-alz-<environment_name>-uksouth-001`. We recommend using `mgmt` for this.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Adding the ability to override SaaS hosted GitHub and Azure DevOps with a self-hosted VCS url. 

NOTE: This is not something we can test and some features, such as Workload identity federation will not work with self hosted yet.

## This PR fixes/adds/changes/removes

1. #13 

### Breaking Changes

None

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
