### PR TITLE
feature: subscription override field

### DIFF
--- a/bootstrap/azuredevops/providers.tf
+++ b/bootstrap/azuredevops/providers.tf
@@ -16,6 +16,7 @@ terraform {
 }
 
 provider "azurerm" {
+  subscription_id = coalesce(var.azure_subscription_id, data.azurerm_client_config.current.subscription_id)
   features {
     resource_group {
       prevent_deletion_if_contains_resources = false

--- a/bootstrap/azuredevops/providers.tf
+++ b/bootstrap/azuredevops/providers.tf
@@ -16,7 +16,7 @@ terraform {
 }
 
 provider "azurerm" {
-  subscription_id = coalesce(var.azure_subscription_id, data.azurerm_client_config.current.subscription_id)
+  subscription_id = var.azure_subscription_id == "" ? null : var.azure_subscription_id
   features {
     resource_group {
       prevent_deletion_if_contains_resources = false

--- a/bootstrap/azuredevops/variables.tf
+++ b/bootstrap/azuredevops/variables.tf
@@ -21,7 +21,7 @@ variable "azure_location" {
 }
 
 variable "azure_subscription_id" {
-  description = "Azure Subscription ID for the landing zone management resources|5|azure_subscription_id"
+  description = "Azure Subscription ID for the landing zone management resources. Leave empty to use the az login subscription|5|azure_subscription_id"
   type        = string
   default     = ""
 }

--- a/bootstrap/azuredevops/variables.tf
+++ b/bootstrap/azuredevops/variables.tf
@@ -20,44 +20,50 @@ variable "azure_location" {
   type        = string
 }
 
+variable "azure_subscription_id" {
+  description = "Azure Subscription ID for the landing zone management resources|5|azure_subscription_id"
+  type        = string
+  default     = ""
+}
+
 variable "service_name" {
-  description = "Used to build up the default resource names (e.g. rg-<service_name>-mgmt-uksouth-001)|5|azure_name_section"
+  description = "Used to build up the default resource names (e.g. rg-<service_name>-mgmt-uksouth-001)|6|azure_name_section"
   type        = string
   default     = "alz"
 }
 
 variable "environment_name" {
-  description = "Used to build up the default resource names (e.g. rg-alz-<environment_name>-uksouth-001)|6|azure_name_section"
+  description = "Used to build up the default resource names (e.g. rg-alz-<environment_name>-uksouth-001)|7|azure_name_section"
   type        = string
   default     = "mgmt"
 }
 
 variable "postfix_number" {
-  description = "Used to build up the default resource names (e.g. rg-alz-mgmt-uksouth-<postfix_number>)|7|number"
+  description = "Used to build up the default resource names (e.g. rg-alz-mgmt-uksouth-<postfix_number>)|8|number"
   type        = number
   default     = 1
 }
 
 variable "azure_devops_use_organisation_legacy_url" {
-  description = "Use the legacy Azure DevOps URL (<organisation>.visualstudio.com) instead of the new URL (dev.azure.com/<organization>)|8|bool"
+  description = "Use the legacy Azure DevOps URL (<organisation>.visualstudio.com) instead of the new URL (dev.azure.com/<organization>)|9|bool"
   type        = bool
   default     = false
 }
 
 variable "azure_devops_create_project" {
-  description = "Create the Azure DevOps project if it does not exist|9|bool"
+  description = "Create the Azure DevOps project if it does not exist|10|bool"
   type        = bool
   default     = true
 }
 
 variable "azure_devops_project_name" {
-  description = "The name of the Azure DevOps project to use or create for the deployment|10"
+  description = "The name of the Azure DevOps project to use or create for the deployment|11"
   type        = string
 }
 
 variable "azure_devops_authentication_scheme" {
   type        = string
-  description = "The authentication scheme to use for the Azure DevOps Pipelines|11|auth_scheme"
+  description = "The authentication scheme to use for the Azure DevOps Pipelines|12|auth_scheme"
   validation {
     condition     = can(regex("^(ManagedServiceIdentity|WorkloadIdentityFederation)$", var.azure_devops_authentication_scheme))
     error_message = "azure_devops_authentication_scheme must be either ManagedServiceIdentity or WorkloadIdentityFederation"
@@ -66,19 +72,19 @@ variable "azure_devops_authentication_scheme" {
 }
 
 variable "apply_approvers" {
-  description = "Apply stage approvers to the action / pipeline, must be a list of SPNs separate by a comma (e.g. abcdef@microsoft.com,ghijklm@microsoft.com)|12"
+  description = "Apply stage approvers to the action / pipeline, must be a list of SPNs separate by a comma (e.g. abcdef@microsoft.com,ghijklm@microsoft.com)|13"
   type        = list(string)
   default     = []
 }
 
 variable "root_management_group_display_name" {
-  description = "The root management group display name|13"
+  description = "The root management group display name|14"
   type        = string
   default     = "Tenant Root Group"
 }
 
 variable "additional_files" {
-  description = "Additional files to upload to the repository. This must be specified as a comma-separated list of absolute file paths (e.g. c:\\config\\config.yaml or /home/user/config/config.yaml)|14"
+  description = "Additional files to upload to the repository. This must be specified as a comma-separated list of absolute file paths (e.g. c:\\config\\config.yaml or /home/user/config/config.yaml)|15"
   type        = list(string)
   default     = []
 }
@@ -89,7 +95,7 @@ variable "agent_container_image" {
 }
 
 variable "target_subscriptions" {
-  description = "The target subscriptions to apply onwer permissions to|hidden_azure_subscription_ids"
+  description = "The target subscriptions to apply owner permissions to|hidden_azure_subscription_ids"
   type        = list(string)
 }
 

--- a/bootstrap/github/providers.tf
+++ b/bootstrap/github/providers.tf
@@ -16,6 +16,7 @@ terraform {
 }
 
 provider "azurerm" {
+  subscription_id = coalesce(var.azure_subscription_id, data.azurerm_client_config.current.subscription_id)
   features {
     resource_group {
       prevent_deletion_if_contains_resources = false

--- a/bootstrap/github/providers.tf
+++ b/bootstrap/github/providers.tf
@@ -16,7 +16,7 @@ terraform {
 }
 
 provider "azurerm" {
-  subscription_id = coalesce(var.azure_subscription_id, data.azurerm_client_config.current.subscription_id)
+  subscription_id = var.azure_subscription_id == "" ? null : var.azure_subscription_id
   features {
     resource_group {
       prevent_deletion_if_contains_resources = false

--- a/bootstrap/github/variables.tf
+++ b/bootstrap/github/variables.tf
@@ -21,7 +21,7 @@ variable "azure_location" {
 }
 
 variable "azure_subscription_id" {
-  description = "Azure Subscription ID for the landing zone management resources|5|azure_subscription_id"
+  description = "Azure Subscription ID for the landing zone management resources. Leave empty to use the az login subscription|5|azure_subscription_id"
   type        = string
   default     = ""
 }

--- a/bootstrap/github/variables.tf
+++ b/bootstrap/github/variables.tf
@@ -20,44 +20,50 @@ variable "azure_location" {
   type        = string
 }
 
+variable "azure_subscription_id" {
+  description = "Azure Subscription ID for the landing zone management resources|5|azure_subscription_id"
+  type        = string
+  default     = ""
+}
+
 variable "service_name" {
-  description = "Used to build up the default resource names (e.g. rg-<service_name>-mgmt-uksouth-001)|5|azure_name_section"
+  description = "Used to build up the default resource names (e.g. rg-<service_name>-mgmt-uksouth-001)|6|azure_name_section"
   type        = string
   default     = "alz"
 }
 
 variable "environment_name" {
-  description = "Used to build up the default resource names (e.g. rg-alz-<environment_name>-uksouth-001)|6|azure_name_section"
+  description = "Used to build up the default resource names (e.g. rg-alz-<environment_name>-uksouth-001)|7|azure_name_section"
   type        = string
   default     = "mgmt"
 }
 
 variable "postfix_number" {
-  description = "Used to build up the default resource names (e.g. rg-alz-mgmt-uksouth-<postfix_number>)|7|number"
+  description = "Used to build up the default resource names (e.g. rg-alz-mgmt-uksouth-<postfix_number>)|8|number"
   type        = number
   default     = 1
 }
 
 variable "apply_approvers" {
-  description = "Apply stage approvers to the action / pipeline, must be a list of SPNs separate by a comma (e.g. abcdef@microsoft.com,ghijklm@microsoft.com)|8"
+  description = "Apply stage approvers to the action / pipeline, must be a list of SPNs separate by a comma (e.g. abcdef@microsoft.com,ghijklm@microsoft.com)|9"
   type        = list(string)
   default     = []
 }
 
 variable "repository_visibility" {
-  description = "The visibility of the repository. Must be 'public' if your organization is not licensed|9|repo_visibility"
+  description = "The visibility of the repository. Must be 'public' if your organization is not licensed|10|repo_visibility"
   type        = string
   default     = "private"
 }
 
 variable "root_management_group_display_name" {
-  description = "The root management group display name|10"
+  description = "The root management group display name|11"
   type        = string
   default     = "Tenant Root Group"
 }
 
 variable "additional_files" {
-  description = "Additional files to upload to the repository. This must be specified as a comma-separated list of absolute file paths (e.g. c:\\config\\config.yaml or /home/user/config/config.yaml)|11"
+  description = "Additional files to upload to the repository. This must be specified as a comma-separated list of absolute file paths (e.g. c:\\config\\config.yaml or /home/user/config/config.yaml)|12"
   type        = list(string)
   default     = []
 }

--- a/docs/wiki/[User-Guide]-Quick-Start-Phase-2.md
+++ b/docs/wiki/[User-Guide]-Quick-Start-Phase-2.md
@@ -21,6 +21,7 @@ The inputs differ depending on the VCS you have chosen:
     1. `version_control_system_access_token`: Enter the Azure DevOps PAT you generated in a previous step.
     1. `version_control_system_organization`: Enter the name of your Azure DevOps organization.
     1. `azure_location`: Enter the Azure region where you would like to deploy the storage account and identity for your continuous delivery pipeline. This field expects the `name` of the region, such as `uksouth`. You can find a full list of names by running `az account list-locations -o table`.
+    1. `azure_subscription_id`: Enter the id of the subscription in which you would like to deploy the storage account and identity for your continuous delivery pipeline. If left blank, the subscription you are connected to via `az login` will be used.
     1. `service_name`: This is used to build up the names of your Azure and Azure DevOps resources, for example `rg-<service_name>-mgmt-uksouth-001`. We recommend using `alz` for this.
     1. `environment_name`: This is used to build up the names of your Azure and Azure DevOps resources, for example `rg-alz-<environment_name>-uksouth-001`. We recommend using `mgmt` for this.
     1. `postfix_number`: This is used to build up the names of your Azure and Azure DevOps resources, for example `rg-alz-mgmt-uksouth-<postfix_number>`. We recommend using `1` for this.
@@ -46,6 +47,7 @@ The inputs differ depending on the VCS you have chosen:
     1. `version_control_system_access_token`: Enter the GitHub PAT you generated in a previous step.
     1. `version_control_system_organization`: Enter the name of your GitHub organization.
     1. `azure_location`: Enter the Azure region where you would like to deploy the storage account and identity for your continuous delivery pipeline. This field expects the `name` of the region, such as `uksouth`. You can find a full list of names by running `az account list-locations -o table`.
+    1. `azure_subscription_id`: Enter the id of the subscription in which you would like to deploy the storage account and identity for your continuous delivery pipeline. If left blank, the subscription you are connected to via `az login` will be used.
     1. `service_name`: This is used to build up the names of your Azure and GitHub resources, for example `rg-<service_name>-mgmt-uksouth-001`. We recommend using `alz` for this.
     1. `environment_name`: This is used to build up the names of your Azure and GitHub resources, for example `rg-alz-<environment_name>-uksouth-001`. We recommend using `mgmt` for this.
     1. `postfix_number`: This is used to build up the names of your Azure and GitHub resources, for example `rg-alz-mgmt-uksouth-<postfix_number>`. We recommend using `1` for this.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Adds an `azure_subscription_id` variable that defaults to the connected subscription if left blank. This can be used to target a subscription other than the one connected to for the bootstrap resources.

A future iteration could update this field to use the `subscription_id_management` field in the starter module, but would require updates to the ALZ PowerShell module to achieve that in a robust way.

## This PR fixes/adds/changes/removes

1. #15 

### Breaking Changes

None. Defaults to the connected subscription if none is supplied, which is the existing behaviour.

## Testing Evidence

Tested with this version of ALZ PowerShell module: https://github.com/Azure/ALZ-PowerShell-Module/pull/77

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
