### PR TITLE
bug fix for pipeline permissions

### DIFF
--- a/templates/ci_cd/github/cd.yaml
+++ b/templates/ci_cd/github/cd.yaml
@@ -19,5 +19,8 @@ jobs:
   plan_and_apply:
     uses: ${organization_name}/${repository_name_templates}/${cd_template_path}@main
     name: 'CD'
+    permissions:
+      id-token: write
+      contents: read
     with:
       terraform_action: $${{ github.event.inputs.terraform_action }}

--- a/templates/ci_cd/github/ci.yaml
+++ b/templates/ci_cd/github/ci.yaml
@@ -10,3 +10,7 @@ jobs:
   validate_and_plan:
     uses: ${organization_name}/${repository_name_templates}/${ci_template_path}@main
     name: 'CI'
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write

--- a/templates/ci_cd/github/templates/ci.yaml
+++ b/templates/ci_cd/github/templates/ci.yaml
@@ -7,6 +7,7 @@ jobs:
   validate:
     name: Validate Terraform
     runs-on: ubuntu-latest
+    environment: ${environment_name_plan}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR fixes a reported bug with GitHub actions permissions.

The reason we have to set the `environment` in the validation job is due to known bug in GitHub. If you alter the token subject to specify environment, then any jobs under the scope of the `id-token: write` permission that do not have an environment cause the pipeline to immediately bomb out with an unexpected error and no details. This has been reported to GitHub and they have replicated it, but we need to have the workaround for now. In this use case it does not cause any security issue.

## This PR fixes/adds/changes/removes

1. #53 

### Breaking Changes

1. None

## Testing Evidence

Run an end to end test with the lowered action permissions set on the org.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
