### PR TITLE
Minor typo in hub var.tf and Recommendation to Quick Start content

### DIFF
--- a/docs/wiki/[User-Guide]-Quick-Start-Phase-2-Azure-DevOps.md
+++ b/docs/wiki/[User-Guide]-Quick-Start-Phase-2-Azure-DevOps.md
@@ -4,7 +4,7 @@
 1. In your PowerShell Core (pwsh) terminal type `New-ALZEnvironment -i "terraform" -c "azuredevops"`.
 1. The module will download the latest accelerator and then prompt you for inputs.
 1. Fill out the following inputs:
-    1. `starter_module`: This is the choice of [Starter Modules][wiki_starter_modules], which is the baseline configuration you want for your Azure landing zone. This also determine the second set of input you'll be prompted for here.
+    1. `starter_module`: This is the choice of [Starter Modules][wiki_starter_modules], which is the baseline configuration you want for your Azure landing zone, E.g. `basic` , `hubnetworking` or `complete`. This also determines the second set of inputs you'll be prompted for here.
     1. `azure_devops_personal_access_token`: Enter the Azure DevOps PAT you generated in a previous step.
     1. `azure_devops_organization_name`: Enter the name of your Azure DevOps organization. This is the section of the url after `dev.azure.com` or before `.visualstudio.com`. E.g. enter `my-org` for `https://dev.azure.com/my-org`.
     1. `use_separate_repository_for_pipeline_templates`: Determine whether to create a separate repository to store pipeline templates as an extra layer of security. Set to `false` if you don't wish to secure you pipeline templates by using a separate repository. This will default to `true`.

--- a/docs/wiki/[User-Guide]-Quick-Start-Phase-2-GitHub.md
+++ b/docs/wiki/[User-Guide]-Quick-Start-Phase-2-GitHub.md
@@ -4,7 +4,7 @@
 1. In your PowerShell Core (pwsh) terminal type `New-ALZEnvironment -i "terraform" -c "github"`.
 1. The module will download the latest accelerator and then prompt you for inputs.
 1. Fill out the following inputs:
-    1. `starter_module`: This is the choice of [Starter Module][wiki_starter_modules], which is the baseline configuration you want for your Azure landing zone. This also determine the second set of input you'll be prompted for here.
+    1. `starter_module`: This is the choice of [Starter Modules][wiki_starter_modules], which is the baseline configuration you want for your Azure landing zone, E.g. `basic` , `hubnetworking` or `complete`. This also determines the second set of inputs you'll be prompted for here.
     1. `github_personal_access_token`: Enter the GitHub PAT you generated in a previous step.
     1. `github_organization_name`: Enter the name of your GitHub organization. This is the section of the url after `github.com`. E.g. enter `my-org` for `https://github.com/my-org`.
     1. `use_separate_repository_for_workflow_templates`: Determine whether to create a separate repository to store pipeline templates as an extra layer of security. Set to `false` if you don't wish to secure you pipeline templates by using a separate repository. This will default to `true`.

--- a/docs/wiki/[User-Guide]-Quick-Start-Phase-2-Local.md
+++ b/docs/wiki/[User-Guide]-Quick-Start-Phase-2-Local.md
@@ -4,7 +4,7 @@
 1. In your PowerShell Core (pwsh) terminal type `New-ALZEnvironment -i "terraform" -c "local"`.
 1. The module will download the latest accelerator and then prompt you for inputs.
 1. Fill out the following inputs:
-    1. `starter_module`: This is the choice of [Starter Modules][wiki_starter_modules], which is the baseline configuration you want for your Azure landing zone. This also determine the second set of input you'll be prompted for here.
+    1. `starter_module`: This is the choice of [Starter Modules][wiki_starter_modules], which is the baseline configuration you want for your Azure landing zone, E.g. `basic` , `hubnetworking` or `complete`. This also determines the second set of inputs you'll be prompted for here.
     1. `target_directory`: This is the directory where the ALZ module code will be created. This defaults a directory called `local` in the root of the accelerator directory.
     1. `create_bootstrap_resources_in_azure`: This determines whether the bootstrap will create the resources in Azure (e.g storage account for state, identities, etc). This defaults to `true`.
     1. `bootstrap_location`: Enter the Azure region where you would like to deploy the storage account and identity for your continuous delivery pipeline. This field expects the `name` of the region, such as `uksouth`. You can find a full list of names by running `az account list-locations -o table`.

--- a/templates/hubnetworking/variables.tf
+++ b/templates/hubnetworking/variables.tf
@@ -36,12 +36,12 @@ variable "hub_virtual_network_address_prefix" {
 }
 
 variable "firewall_subnet_address_prefix" {
-  description = "The IP address range foe the firewall subnet in CIDR format|8|cidr_range"
+  description = "The IP address range for the firewall subnet in CIDR format|8|cidr_range"
   type        = string
 }
 
 variable "gateway_subnet_address_prefix" {
-  description = "The IP address range foe the gateway subnet in CIDR format|9|cidr_range"
+  description = "The IP address range for the gateway subnet in CIDR format|9|cidr_range"
   type        = string
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Minor typo found in templates/hubnetworking/variables.tf during testing, foe changed to for.

## This PR fixes/adds/changes/removes

1. Changes foe to for in templates/hubnetworking/variables.tf for 2 x variables.
2. Adds additional advice into 3 x quick start guides which for step 1 adding in E.g. `basic` , `hubnetworking` or `complete`. in local, GitHub, and DevOps guides. Also updating a couple of minor typos.

### Breaking Changes

1. N/A

## Testing Evidence

None required as these are just spelling updates to var and ReadMe files.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.
