### PR TITLE
enhancment: set azure devops timeout to max

### DIFF
--- a/templates/ci_cd/azuredevops/templates/cd.yaml
+++ b/templates/ci_cd/azuredevops/templates/cd.yaml
@@ -14,6 +14,7 @@ stages:
         pool:
           ${agent_pool_configuration_plan}
         environment: ${environment_name_plan}
+        timeoutInMinutes: 0
         strategy:
           runOnce:
             deploy:
@@ -64,6 +65,7 @@ stages:
         pool:
           ${agent_pool_configuration_apply}
         environment: ${environment_name_apply}
+        timeoutInMinutes: 0
         strategy:
           runOnce:
             deploy:

--- a/templates/ci_cd/azuredevops/templates/ci.yaml
+++ b/templates/ci_cd/azuredevops/templates/ci.yaml
@@ -25,6 +25,7 @@ stages:
         pool:
           ${agent_pool_configuration_plan}
         environment: ${environment_name_plan}
+        timeoutInMinutes: 0
         strategy:
           runOnce:
             deploy:


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

The default timeout of 60 minutes can sometimes be breached due to the nature of the ALZ modules

## This PR fixes/adds/changes/removes

N/A

### Breaking Changes

None

## Testing Evidence

e2e tests run

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
