### PR TITLE
Added new condition option, for SPN role assignment which is now required

### DIFF
--- a/docs/wiki/[User-Guide]-Quick-Start-Phase-1-Service-Principal.md
+++ b/docs/wiki/[User-Guide]-Quick-Start-Phase-1-Service-Principal.md
@@ -34,7 +34,8 @@
     1. Click `Owner` to highlight the row and then click `Next`.
     1. Leave the `User, group or service principal` option checked.
     1. Click `+ Select Members` and search for your SPN in the search box on the right.
-    1. Click on your User to highlight it and then click `Select`.
+    1. Click on your User to highlight it and then click `Select` and then click `Next`.
+    1. Click the `Allow user to assign all roles (highly privileged)` option.
     1. Click `Review + assign`, then click `Review + assign` again when the warning appears.
     1. Wait for the role to be assigned and move onto the next subscription.
 1. Search for `Management Groups` and click to navigate to the management groups view.


### PR DESCRIPTION

## Overview/Summary

When adding a role assignment, the conditions tab has an option next to "What user can do", which is now required for highly privileged roles, such as Owner

## This PR fixes/adds/changes/removes

1. Updated the Service Principal user guide, under the "Create Permissions" section, to reflect the required option for assigning privileged roles

### Breaking Changes

1. N/A

## Testing Evidence

Change to the User-guide for Service Principal role assignment, tested on fork to ensure the text reads correctly

## As part of this Pull Request I have

- [x ] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [ x] Performed testing and provided evidence.
- [ x] Updated relevant and associated documentation.
