### PR TITLE
Update the `strict_subscription_association` default value to false

### DIFF
--- a/templates/complete/main.tf
+++ b/templates/complete/main.tf
@@ -37,7 +37,7 @@ module "enterprise_scale" {
   resource_custom_timeouts                                = try(local.archetypes.resource_custom_timeouts, {})
   root_id                                                 = try(local.archetypes.root_id, "es")
   root_name                                               = try(local.archetypes.root_name, "Enterprise-Scale")
-  strict_subscription_association                         = try(local.archetypes.strict_subscription_association, true)
+  strict_subscription_association                         = try(local.archetypes.strict_subscription_association, false)
   subscription_id_connectivity                            = try(local.archetypes.subscription_id_connectivity, var.subscription_id_connectivity)
   subscription_id_identity                                = try(local.archetypes.subscription_id_identity, var.subscription_id_identity)
   subscription_id_management                              = try(local.archetypes.subscription_id_management, var.subscription_id_management)

--- a/templates/complete_multi_region/modules/management-es/main.tf
+++ b/templates/complete_multi_region/modules/management-es/main.tf
@@ -35,7 +35,7 @@ module "management_groups" {
   resource_custom_timeouts                                = try(var.settings.resource_custom_timeouts, {})
   root_id                                                 = try(var.settings.root_id, "alz")
   root_name                                               = try(var.settings.root_name, "Azure-Landing-Zones")
-  strict_subscription_association                         = try(var.settings.strict_subscription_association, true)
+  strict_subscription_association                         = try(var.settings.strict_subscription_association, false)
   subscription_id_connectivity                            = var.settings.subscription_id_connectivity
   subscription_id_identity                                = var.settings.subscription_id_identity
   subscription_id_management                              = var.settings.subscription_id_management
@@ -48,3 +48,4 @@ module "management_groups" {
     azurerm.management   = azurerm.management
   }
 }
+


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Updating the default value of `strict_subscription_association` to `false`
## This PR fixes/adds/changes/removes

1. This change will allow to provision subscriptions outside of the ALZ accelerator and will not remove during the apply. 


### Breaking Changes

## Testing Evidence

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
