### PR TITLE
fix: bastion host default naming convention

### DIFF
--- a/templates/platform_landing_zone/examples/full-multi-region-nva/hub-and-spoke-vnet.tfvars
+++ b/templates/platform_landing_zone/examples/full-multi-region-nva/hub-and-spoke-vnet.tfvars
@@ -52,7 +52,7 @@ custom_replacements = {
     primary_virtual_network_gateway_vpn_name                     = "vgw-hub-vpn-$${starter_location_01}"
     primary_virtual_network_gateway_vpn_public_ip_name           = "pip-vgw-hub-vpn-$${starter_location_01}"
     primary_private_dns_resolver_name                            = "pdr-hub-dns-$${starter_location_01}"
-    primary_bastion_host_name                                    = "btn-hub-$${starter_location_01}"
+    primary_bastion_host_name                                    = "bas-hub-$${starter_location_01}"
     primary_bastion_host_public_ip_name                          = "pip-bastion-hub-$${starter_location_01}"
 
     # Resource names secondary connectivity
@@ -65,7 +65,7 @@ custom_replacements = {
     secondary_virtual_network_gateway_vpn_name                     = "vgw-hub-vpn-$${starter_location_02}"
     secondary_virtual_network_gateway_vpn_public_ip_name           = "pip-vgw-hub-vpn-$${starter_location_02}"
     secondary_private_dns_resolver_name                            = "pdr-hub-dns-$${starter_location_02}"
-    secondary_bastion_host_name                                    = "btn-hub-$${starter_location_02}"
+    secondary_bastion_host_name                                    = "bas-hub-$${starter_location_02}"
     secondary_bastion_host_public_ip_name                          = "pip-bastion-hub-$${starter_location_02}"
 
     # Private DNS Zones primary

--- a/templates/platform_landing_zone/examples/full-multi-region-nva/virtual-wan.tfvars
+++ b/templates/platform_landing_zone/examples/full-multi-region-nva/virtual-wan.tfvars
@@ -50,7 +50,7 @@ custom_replacements = {
     primary_virtual_network_gateway_express_route_name = "vgw-hub-er-$${starter_location_01}"
     primary_virtual_network_gateway_vpn_name           = "vgw-hub-vpn-$${starter_location_01}"
     primary_private_dns_resolver_name                  = "pdr-hub-dns-$${starter_location_01}"
-    primary_bastion_host_name                          = "btn-hub-$${starter_location_01}"
+    primary_bastion_host_name                          = "bas-hub-$${starter_location_01}"
     primary_bastion_host_public_ip_name                = "pip-bastion-hub-$${starter_location_01}"
 
     # Resource names secondary connectivity
@@ -60,7 +60,7 @@ custom_replacements = {
     secondary_virtual_network_gateway_express_route_name = "vgw-hub-er-$${starter_location_02}"
     secondary_virtual_network_gateway_vpn_name           = "vgw-hub-vpn-$${starter_location_02}"
     secondary_private_dns_resolver_name                  = "pdr-hub-dns-$${starter_location_02}"
-    secondary_bastion_host_name                          = "btn-hub-$${starter_location_02}"
+    secondary_bastion_host_name                          = "bas-hub-$${starter_location_02}"
     secondary_bastion_host_public_ip_name                = "pip-bastion-hub-$${starter_location_02}"
 
     # Private DNS Zones primary

--- a/templates/platform_landing_zone/examples/full-multi-region/hub-and-spoke-vnet.tfvars
+++ b/templates/platform_landing_zone/examples/full-multi-region/hub-and-spoke-vnet.tfvars
@@ -54,7 +54,7 @@ custom_replacements = {
     primary_virtual_network_gateway_vpn_name                     = "vgw-hub-vpn-$${starter_location_01}"
     primary_virtual_network_gateway_vpn_public_ip_name           = "pip-vgw-hub-vpn-$${starter_location_01}"
     primary_private_dns_resolver_name                            = "pdr-hub-dns-$${starter_location_01}"
-    primary_bastion_host_name                                    = "btn-hub-$${starter_location_01}"
+    primary_bastion_host_name                                    = "bas-hub-$${starter_location_01}"
     primary_bastion_host_public_ip_name                          = "pip-bastion-hub-$${starter_location_01}"
 
     # Resource names secondary connectivity
@@ -69,7 +69,7 @@ custom_replacements = {
     secondary_virtual_network_gateway_vpn_name                     = "vgw-hub-vpn-$${starter_location_02}"
     secondary_virtual_network_gateway_vpn_public_ip_name           = "pip-vgw-hub-vpn-$${starter_location_02}"
     secondary_private_dns_resolver_name                            = "pdr-hub-dns-$${starter_location_02}"
-    secondary_bastion_host_name                                    = "btn-hub-$${starter_location_02}"
+    secondary_bastion_host_name                                    = "bas-hub-$${starter_location_02}"
     secondary_bastion_host_public_ip_name                          = "pip-bastion-hub-$${starter_location_02}"
 
     # Private DNS Zones primary

--- a/templates/platform_landing_zone/examples/full-multi-region/virtual-wan.tfvars
+++ b/templates/platform_landing_zone/examples/full-multi-region/virtual-wan.tfvars
@@ -51,7 +51,7 @@ custom_replacements = {
     primary_virtual_network_gateway_express_route_name = "vgw-hub-er-$${starter_location_01}"
     primary_virtual_network_gateway_vpn_name           = "vgw-hub-vpn-$${starter_location_01}"
     primary_private_dns_resolver_name                  = "pdr-hub-dns-$${starter_location_01}"
-    primary_bastion_host_name                          = "btn-hub-$${starter_location_01}"
+    primary_bastion_host_name                          = "bas-hub-$${starter_location_01}"
     primary_bastion_host_public_ip_name                = "pip-bastion-hub-$${starter_location_01}"
 
     # Resource names secondary connectivity
@@ -62,7 +62,7 @@ custom_replacements = {
     secondary_virtual_network_gateway_express_route_name = "vgw-hub-er-$${starter_location_02}"
     secondary_virtual_network_gateway_vpn_name           = "vgw-hub-vpn-$${starter_location_02}"
     secondary_private_dns_resolver_name                  = "pdr-hub-dns-$${starter_location_02}"
-    secondary_bastion_host_name                          = "btn-hub-$${starter_location_02}"
+    secondary_bastion_host_name                          = "bas-hub-$${starter_location_02}"
     secondary_bastion_host_public_ip_name                = "pip-bastion-hub-$${starter_location_02}"
 
     # Private DNS Zones primary

--- a/templates/platform_landing_zone/examples/full-single-region/hub-and-spoke-vnet.tfvars
+++ b/templates/platform_landing_zone/examples/full-single-region/hub-and-spoke-vnet.tfvars
@@ -53,7 +53,7 @@ custom_replacements = {
     primary_virtual_network_gateway_vpn_name                     = "vgw-hub-vpn-$${starter_location_01}"
     primary_virtual_network_gateway_vpn_public_ip_name           = "pip-vgw-hub-vpn-$${starter_location_01}"
     primary_private_dns_resolver_name                            = "pdr-hub-dns-$${starter_location_01}"
-    primary_bastion_host_name                                    = "btn-hub-$${starter_location_01}"
+    primary_bastion_host_name                                    = "bas-hub-$${starter_location_01}"
     primary_bastion_host_public_ip_name                          = "pip-bastion-hub-$${starter_location_01}"
 
     # Private DNS Zones primary

--- a/templates/platform_landing_zone/examples/full-single-region/virtual-wan.tfvars
+++ b/templates/platform_landing_zone/examples/full-single-region/virtual-wan.tfvars
@@ -50,7 +50,7 @@ custom_replacements = {
     primary_virtual_network_gateway_express_route_name = "vgw-hub-er-$${starter_location_01}"
     primary_virtual_network_gateway_vpn_name           = "vgw-hub-vpn-$${starter_location_01}"
     primary_private_dns_resolver_name                  = "pdr-hub-dns-$${starter_location_01}"
-    primary_bastion_host_name                          = "btn-hub-$${starter_location_01}"
+    primary_bastion_host_name                          = "bas-hub-$${starter_location_01}"
     primary_bastion_host_public_ip_name                = "pip-bastion-hub-$${starter_location_01}"
 
     # Private DNS Zones primary


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Replace the default naming convention for the Bastion host.

## This PR fixes/adds/changes/removes

1. https://github.com/Azure/ALZ-PowerShell-Module/issues/270

### Breaking Changes

None

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
