### PR TITLE
fix: fixing alz provider lib attribute

### DIFF
--- a/templates/microsoft_cloud_for_industry/financial_services_landing_zone/terraform.tf
+++ b/templates/microsoft_cloud_for_industry/financial_services_landing_zone/terraform.tf
@@ -36,7 +36,7 @@ provider "alz" {
   library_references = [
     {
       path = "platform/fsi"
-      tag  = "2025.03.0"
+      ref  = "2025.03.0"
     },
     {
       custom_url = "${path.root}/lib"

--- a/templates/microsoft_cloud_for_industry/sovereign_landing_zone/terraform.tf
+++ b/templates/microsoft_cloud_for_industry/sovereign_landing_zone/terraform.tf
@@ -36,7 +36,7 @@ provider "alz" {
   library_references = [
     {
       path = "platform/slz"
-      tag  = "2025.03.0"
+      ref  = "2025.03.0"
     },
     {
       custom_url = "${path.root}/lib"


### PR DESCRIPTION
## Overview/Summary

Fixing incorrect attribute tag to ref for alz lib version

## This PR fixes/adds/changes/removes

1. Fixing incorrect attribute tag to ref for alz lib version

### Breaking Changes

1. None

## Testing Evidence

![image](https://github.com/user-attachments/assets/52d30674-9946-40ea-8ffa-8f8d27171aa6)

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
