### PR TITLE
feat: turn off automation account by default

### DIFF
--- a/templates/platform_landing_zone/modules/management_resources/main.tf
+++ b/templates/platform_landing_zone/modules/management_resources/main.tf
@@ -14,7 +14,7 @@ module "management_resources" {
   automation_account_sku_name                                = try(var.management_resource_settings.automation_account_sku_name, null)
   data_collection_rules                                      = try(var.management_resource_settings.data_collection_rules, null)
   enable_telemetry                                           = var.enable_telemetry
-  linked_automation_account_creation_enabled                 = try(var.management_resource_settings.linked_automation_account_creation_enabled, true)
+  linked_automation_account_creation_enabled                 = try(var.management_resource_settings.linked_automation_account_creation_enabled, false)
   log_analytics_solution_plans                               = try(var.management_resource_settings.log_analytics_solution_plans, null)
   log_analytics_workspace_allow_resource_only_permissions    = try(var.management_resource_settings.log_analytics_workspace_allow_resource_only_permissions, true)
   log_analytics_workspace_cmk_for_query_forced               = try(var.management_resource_settings.log_analytics_workspace_cmk_for_query_forced, null)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Turn off the automation account by default to follow ALZ guidance

## This PR fixes/adds/changes/removes

None

### Breaking Changes

The plan will destroy the automation account if it already exists. You can turn it back on in config if you beleive you need it.

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
