### PR TITLE
fix: Support for management-only scenario

### DIFF
--- a/templates/platform_landing_zone/locals.tf
+++ b/templates/platform_landing_zone/locals.tf
@@ -10,8 +10,8 @@ locals {
 
 locals {
   connectivity_enabled                    = var.connectivity_type != local.const.connectivity.none
-  connectivity_virtual_wan_enabled        = var.connectivity_type == local.const.connectivity.virtual_wan && local.connectivity_enabled
-  connectivity_hub_and_spoke_vnet_enabled = var.connectivity_type == local.const.connectivity.hub_and_spoke_vnet && local.connectivity_enabled
+  connectivity_virtual_wan_enabled        = var.connectivity_type == local.const.connectivity.virtual_wan
+  connectivity_hub_and_spoke_vnet_enabled = var.connectivity_type == local.const.connectivity.hub_and_spoke_vnet
 }
 
 # Build an implicit dependency on the resource groups

--- a/templates/platform_landing_zone/locals.tf
+++ b/templates/platform_landing_zone/locals.tf
@@ -10,8 +10,8 @@ locals {
 
 locals {
   connectivity_enabled                    = var.connectivity_type != local.const.connectivity.none
-  connectivity_virtual_wan_enabled        = var.connectivity_type == local.const.connectivity.virtual_wan
-  connectivity_hub_and_spoke_vnet_enabled = var.connectivity_type == local.const.connectivity.hub_and_spoke_vnet
+  connectivity_virtual_wan_enabled        = var.connectivity_type == local.const.connectivity.virtual_wan && local.connectivity_enabled
+  connectivity_hub_and_spoke_vnet_enabled = var.connectivity_type == local.const.connectivity.hub_and_spoke_vnet && local.connectivity_enabled
 }
 
 # Build an implicit dependency on the resource groups

--- a/templates/platform_landing_zone/variables.tf
+++ b/templates/platform_landing_zone/variables.tf
@@ -6,7 +6,7 @@ variable "starter_locations" {
     error_message = "You must provide at least one starter location region."
   }
   validation {
-    condition     = var.connectivity_type == "none" || ((length(var.virtual_wan_virtual_hubs) >= length(var.starter_locations)) || (length(var.hub_and_spoke_vnet_virtual_networks) >= length(var.starter_locations)))
+    condition     = var.connectivity_type == "none" || ((length(var.virtual_wan_virtual_hubs) <= length(var.starter_locations)) || (length(var.hub_and_spoke_vnet_virtual_networks) <= length(var.starter_locations)))
     error_message = "The number of regions supplied in `starter_locations` must match the number of regions specified for connectivity."
   }
 }

--- a/templates/platform_landing_zone/variables.tf
+++ b/templates/platform_landing_zone/variables.tf
@@ -6,7 +6,7 @@ variable "starter_locations" {
     error_message = "You must provide at least one starter location region."
   }
   validation {
-    condition     = var.connectivity_type == "none" || ((length(var.virtual_wan_virtual_hubs) == length(var.starter_locations)) || (length(var.hub_and_spoke_vnet_virtual_networks) == length(var.starter_locations)))
+    condition     = var.connectivity_type == "none" || ((length(var.virtual_wan_virtual_hubs) >= length(var.starter_locations)) || (length(var.hub_and_spoke_vnet_virtual_networks) >= length(var.starter_locations)))
     error_message = "The number of regions supplied in `starter_locations` must match the number of regions specified for connectivity."
   }
 }

--- a/templates/platform_landing_zone/variables.tf
+++ b/templates/platform_landing_zone/variables.tf
@@ -6,7 +6,7 @@ variable "starter_locations" {
     error_message = "You must provide at least one starter location region."
   }
   validation {
-    condition     = (length(var.virtual_wan_virtual_hubs) == length(var.starter_locations)) || (length(var.hub_and_spoke_vnet_virtual_networks) == length(var.starter_locations))
+    condition     = var.connectivity_type == "none" || ((length(var.virtual_wan_virtual_hubs) == length(var.starter_locations)) || (length(var.hub_and_spoke_vnet_virtual_networks) == length(var.starter_locations)))
     error_message = "The number of regions supplied in `starter_locations` must match the number of regions specified for connectivity."
   }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

The validation for `starter_locations `within the platform landing zone fails when `connectivity_type` is set to `none`. These validation changes were introduced in PR #225.

The issue arises because the validation logic still assesses `var.virtual_wan_virtual_hubs` and `var.hub_and_spoke_vnet_virtual_networks`, even though these variables are not supplied when `connectivity_type` is `none`.

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
