### PR TITLE
Update hub-and-spoke-vnet.tfvars firewall policy name change

### DIFF
--- a/templates/platform_landing_zone/examples/full-multi-region/hub-and-spoke-vnet.tfvars
+++ b/templates/platform_landing_zone/examples/full-multi-region/hub-and-spoke-vnet.tfvars
@@ -64,7 +64,7 @@ custom_replacements = {
     # Resource names secondary connectivity
     secondary_virtual_network_name                                 = "vnet-hub-$${starter_location_02}"
     secondary_firewall_name                                        = "fw-hub-$${starter_location_02}"
-    secondary_firewall_policy_name                                 = "fwp-hub-$${starter_location_01}"
+    secondary_firewall_policy_name                                 = "fwp-hub-$${starter_location_02}"
     secondary_firewall_public_ip_name                              = "pip-fw-hub-$${starter_location_02}"
     secondary_route_table_firewall_name                            = "rt-hub-fw-$${starter_location_02}"
     secondary_route_table_user_subnets_name                        = "rt-hub-std-$${starter_location_02}"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Bug found in the name of the second firewall policy name eg.

 secondary_firewall_policy_name                                 = "fwp-hub-$${starter_location_01}"
 
 should be
 
  secondary_firewall_policy_name                                 = "fwp-hub-$${starter_location_02}"

## This PR fixes/

1. The second firewall policy name from having the primary location

### Breaking Changes


## Testing Evidence

I have deployed this code and the second firewall policy name has the second location in the name

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
