### PR TITLE
docs: update url in example readmes

### DIFF
--- a/templates/platform_landing_zone/examples/full-multi-region-nva/README.md
+++ b/templates/platform_landing_zone/examples/full-multi-region-nva/README.md
@@ -22,4 +22,4 @@ The vWAN module does not currently support routes, we'll need to add that per th
 
 ## Documentation
 
-The full documentation for this example can be found over at out [Azure Landing Zones documentation site](https://tbc.com).
+The full documentation for this example can be found over at out [Azure Landing Zones documentation site](https://azure.github.io/Azure-Landing-Zones/accelerator/startermodules/terraform-platform-landing-zone/scenarios/).

--- a/templates/platform_landing_zone/examples/full-multi-region/README.md
+++ b/templates/platform_landing_zone/examples/full-multi-region/README.md
@@ -19,4 +19,4 @@ There are two options for deploying the hub networking:
 
 ## Documentation
 
-The full documentation for this example can be found over at out [Azure Landing Zones documentation site](https://tbc.com).
+The full documentation for this example can be found over at out [Azure Landing Zones documentation site](https://azure.github.io/Azure-Landing-Zones/accelerator/startermodules/terraform-platform-landing-zone/scenarios/).

--- a/templates/platform_landing_zone/examples/full-single-region-nva/README.md
+++ b/templates/platform_landing_zone/examples/full-single-region-nva/README.md
@@ -22,4 +22,4 @@ The vWAN module does not currently support routes, we'll need to add that per th
 
 ## Documentation
 
-The full documentation for this example can be found over at our [Azure Landing Zones documentation site](https://tbc.com).
+The full documentation for this example can be found over at our [Azure Landing Zones documentation site](https://azure.github.io/Azure-Landing-Zones/accelerator/startermodules/terraform-platform-landing-zone/scenarios/).

--- a/templates/platform_landing_zone/examples/full-single-region/README.md
+++ b/templates/platform_landing_zone/examples/full-single-region/README.md
@@ -19,4 +19,4 @@ There are two options for deploying the hub networking:
 
 ## Documentation
 
-The full documentation for this example can be found over at out [Azure Landing Zones documentation site](https://tbc.com).
+The full documentation for this example can be found over at out [Azure Landing Zones documentation site](https://azure.github.io/Azure-Landing-Zones/accelerator/startermodules/terraform-platform-landing-zone/scenarios/).

--- a/templates/platform_landing_zone/examples/management-only/README.md
+++ b/templates/platform_landing_zone/examples/management-only/README.md
@@ -15,4 +15,4 @@ There is one option for deploying:
 
 ## Documentation
 
-The full documentation for this example can be found over at out [Azure Landing Zones documentation site](https://tbc.com).
+The full documentation for this example can be found over at out [Azure Landing Zones documentation site](https://azure.github.io/Azure-Landing-Zones/accelerator/startermodules/terraform-platform-landing-zone/scenarios/).


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

For some reason the URL to the Azure Landing Zones documentation site in all of the example `README` files points to a financial institution and not a Microsoft owned website. For simplicity I have just updated the urls to use https://azure.github.io/Azure-Landing-Zones/accelerator/startermodules/terraform-platform-landing-zone/scenarios/ where an overview of all the scenarios are listed

## This PR fixes/adds/changes/removes

1. Faulty URLs in `README` files

## Testing Evidence

not applicable. This pr doesn't touch any code

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
