### PR TITLE
fix: vwan and policy role assignments

### DIFF
--- a/templates/platform_landing_zone/examples/full-multi-region-nva/virtual-wan.tfvars
+++ b/templates/platform_landing_zone/examples/full-multi-region-nva/virtual-wan.tfvars
@@ -398,6 +398,7 @@ virtual_wan_virtual_hubs = {
           address_prefixes = ["$${primary_nva_subnet_address_prefix}"]
         }
       }
+      # virtual_network_connection_name = "private_dns_vnet_primary"  # Backwards compatibility
     }
   }
   secondary = {
@@ -463,6 +464,7 @@ virtual_wan_virtual_hubs = {
           address_prefixes = ["$${secondary_nva_subnet_address_prefix}"]
         }
       }
+      # virtual_network_connection_name = "private_dns_vnet_secondary"  # Backwards compatibility
     }
   }
 }

--- a/templates/platform_landing_zone/examples/full-multi-region/virtual-wan.tfvars
+++ b/templates/platform_landing_zone/examples/full-multi-region/virtual-wan.tfvars
@@ -398,6 +398,7 @@ virtual_wan_virtual_hubs = {
       enabled       = "$${primary_sidecar_virtual_network_enabled}"
       name          = "$${primary_sidecar_virtual_network_name}"
       address_space = ["$${primary_side_car_virtual_network_address_space}"]
+      # virtual_network_connection_name = "private_dns_vnet_primary"  # Backwards compatibility
     }
   }
   secondary = {
@@ -466,6 +467,7 @@ virtual_wan_virtual_hubs = {
       enabled       = "$${secondary_sidecar_virtual_network_enabled}"
       name          = "$${secondary_sidecar_virtual_network_name}"
       address_space = ["$${secondary_side_car_virtual_network_address_space}"]
+      # virtual_network_connection_name = "private_dns_vnet_secondary"  # Backwards compatibility
     }
   }
 }

--- a/templates/platform_landing_zone/examples/full-single-region-nva/virtual-wan.tfvars
+++ b/templates/platform_landing_zone/examples/full-single-region-nva/virtual-wan.tfvars
@@ -355,6 +355,7 @@ virtual_wan_virtual_hubs = {
           address_prefixes = ["$${primary_nva_subnet_address_prefix}"]
         }
       }
+      # virtual_network_connection_name = "private_dns_vnet_primary"  # Backwards compatibility
     }
   }
 }

--- a/templates/platform_landing_zone/examples/full-single-region/virtual-wan.tfvars
+++ b/templates/platform_landing_zone/examples/full-single-region/virtual-wan.tfvars
@@ -359,6 +359,7 @@ virtual_wan_virtual_hubs = {
       enabled       = "$${primary_sidecar_virtual_network_enabled}"
       name          = "$${primary_sidecar_virtual_network_name}"
       address_space = ["$${primary_side_car_virtual_network_address_space}"]
+      # virtual_network_connection_name = "private_dns_vnet_primary"  # Backwards compatibility
     }
   }
 }

--- a/templates/platform_landing_zone/locals.tf
+++ b/templates/platform_landing_zone/locals.tf
@@ -45,3 +45,17 @@ locals {
     ]
   }
 }
+
+# Handle Policy Assignment Role Assignments
+locals {
+  policy_assignments_to_modify = { for assignment_key, assignment_value in var.policy_default_values_filtering.policy_assignment_names_to_check : assignment_key => flatten([for policy_assignments_to_modify_key, policy_assignments_to_modify_value in try(module.config.management_group_settings.policy_assignments_to_modify, {}) : [for ef in values(policy_assignments_to_modify_value.policy_assignments) : try(ef.enforcement_mode, "Unknown") != "DoNotEnforce"] if contains(keys(policy_assignments_to_modify_value.policy_assignments), assignment_value)]) }
+  policy_assignment_enforced   = { for assignment_key, assignment_value in var.policy_default_values_filtering.policy_assignment_names_to_check : assignment_key => length(local.policy_assignments_to_modify[assignment_key]) == 0 || alltrue(local.policy_assignments_to_modify[assignment_key]) }
+
+  policy_default_values = { for policy_default_value_key, policy_default_value_value in try(module.config.management_group_settings.policy_default_values, {}) : policy_default_value_key => policy_default_value_value if try(local.policy_assignment_enforced[var.policy_default_values_filtering.policy_default_values_to_remove[policy_default_value_key]], true) }
+  management_group_settings = var.policy_default_values_filtering.enabled ? merge(
+    try(module.config.management_group_settings, {}),
+    {
+      policy_default_values = local.policy_default_values
+    }
+  ) : module.config.management_group_settings
+}

--- a/templates/platform_landing_zone/main.connectivity.virtual.wan.tf
+++ b/templates/platform_landing_zone/main.connectivity.virtual.wan.tf
@@ -1,6 +1,6 @@
 module "virtual_wan" {
   source  = "Azure/avm-ptn-alz-connectivity-virtual-wan/azurerm"
-  version = "0.8.0"
+  version = "0.9.0"
 
   count = local.connectivity_virtual_wan_enabled ? 1 : 0
 

--- a/templates/platform_landing_zone/main.management.tf
+++ b/templates/platform_landing_zone/main.management.tf
@@ -18,7 +18,7 @@ module "management_groups" {
   count = local.management_groups_enabled ? 1 : 0
 
   enable_telemetry          = var.enable_telemetry
-  management_group_settings = module.config.management_group_settings
+  management_group_settings = local.management_group_settings
   dependencies              = local.management_group_dependencies
 }
 

--- a/templates/platform_landing_zone/terraform.tf
+++ b/templates/platform_landing_zone/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     alz = {
       source  = "Azure/alz"
-      version = "~> 0.16"
+      version = "0.18.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/templates/platform_landing_zone/variables.management.tf
+++ b/templates/platform_landing_zone/variables.management.tf
@@ -13,3 +13,28 @@ variable "management_group_settings" {
 The settings for the management groups. Details of the settings can be found in the module documentation at https://registry.terraform.io/modules/Azure/avm-ptn-alz
 DESCRIPTION
 }
+
+variable "policy_default_values_filtering" {
+  type = object({
+    enabled = optional(bool, true)
+    policy_assignment_names_to_check = optional(map(string), {
+      dns  = "Deploy-Private-DNS-Zones",
+      ddos = "Enable-DDoS-VNET"
+    })
+    policy_default_values_to_remove = optional(map(string), {
+      private_dns_zone_subscription_id     = "dns"
+      private_dns_zone_region              = "dns"
+      private_dns_zone_resource_group_name = "dns"
+      ddos_protection_plan_id              = "ddos"
+    })
+  })
+  default     = {}
+  description = <<DESCRIPTION
+This variable is used to prevent the creation of policy assignment role assignments for policies that are explicitly set to 'DoNotEnforce'.
+
+- `enabled`: Set to `true` to enable filtering of policy assignment role assignments.
+- `policy_assignment_names_to_check`: A map of policy assignment names to check for filtering.
+- `policy_default_values_to_remove`: A map of policy default values to remove from the policy assignment role assignments.
+
+DESCRIPTION
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Fix vwan sku issue for azurerm provider bug where it doesn't handle null correctly.

Fix vwan sidecar nework links issue where they were inadvertently linked to the DNS zones being able due to a historical reason.

Temporary fix for policy role assignments attempting to be created for DNS zones that don't exist. This will be superceded by a change to not deploy the policy assignment at all.

## This PR fixes/adds/changes/removes

N/A

### Breaking Changes

- The sidecar vnet hub network connection name now defaults to a new value. This can be overriden by uncommenting the lines added to the config file to avoid re-creating them.

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
