### PR TITLE
fix(examples): add DDoS protection plan configuration to SMB single-region examples

### DIFF
--- a/templates/platform_landing_zone/examples/smb-single-region/hub-and-spoke-vnet.tfvars
+++ b/templates/platform_landing_zone/examples/smb-single-region/hub-and-spoke-vnet.tfvars
@@ -62,11 +62,13 @@ custom_replacements = {
     management_resource_group_name               = "rg-management-$${starter_location_01}"
     connectivity_hub_primary_resource_group_name = "rg-hub-$${starter_location_01}"
     dns_resource_group_name                      = "rg-hub-dns-$${starter_location_01}"
+    ddos_resource_group_name                     = "rg-hub-ddos-$${starter_location_01}"
     asc_export_resource_group_name               = "rg-asc-export-$${starter_location_01}"
     service_health_alerts_resource_group_name    = "rg-service-health-alerts-$${starter_location_01}"
 
     # Resource names management
     log_analytics_workspace_name            = "law-management-$${starter_location_01}"
+    ddos_protection_plan_name               = "ddos-$${starter_location_01}"
     ama_user_assigned_managed_identity_name = "uami-management-ama-$${starter_location_01}"
     dcr_change_tracking_name                = "dcr-change-tracking"
     dcr_defender_sql_name                   = "dcr-defender-sql"
@@ -85,6 +87,7 @@ custom_replacements = {
   */
   resource_group_identifiers = {
     management_resource_group_id           = "/subscriptions/$${subscription_id_management}/resourcegroups/$${management_resource_group_name}"
+    ddos_protection_plan_resource_group_id = "/subscriptions/$${subscription_id_connectivity}/resourcegroups/$${ddos_resource_group_name}"
     primary_connectivity_resource_group_id = "/subscriptions/$${subscription_id_connectivity}/resourceGroups/$${connectivity_hub_primary_resource_group_name}"
     dns_resource_group_id                  = "/subscriptions/$${subscription_id_connectivity}/resourceGroups/$${dns_resource_group_name}"
   }
@@ -101,6 +104,7 @@ custom_replacements = {
     ama_vm_insights_data_collection_rule_id     = "$${management_resource_group_id}/providers/Microsoft.Insights/dataCollectionRules/$${dcr_vm_insights_name}"
     ama_user_assigned_managed_identity_id       = "$${management_resource_group_id}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$${ama_user_assigned_managed_identity_name}"
     log_analytics_workspace_id                  = "$${management_resource_group_id}/providers/Microsoft.OperationalInsights/workspaces/$${log_analytics_workspace_name}"
+    ddos_protection_plan_id                     = "$${ddos_protection_plan_resource_group_id}/providers/Microsoft.Network/ddosProtectionPlans/$${ddos_protection_plan_name}"
   }
 }
 
@@ -161,13 +165,14 @@ management_group_settings = {
     ama_user_assigned_managed_identity_id       = "$${ama_user_assigned_managed_identity_id}"
     ama_user_assigned_managed_identity_name     = "$${ama_user_assigned_managed_identity_name}"
     log_analytics_workspace_id                  = "$${log_analytics_workspace_id}"
-    private_dns_zone_subscription_id            = "$${subscription_id_connectivity}"
-    private_dns_zone_region                     = "$${starter_location_01}"
-    private_dns_zone_resource_group_name        = "$${dns_resource_group_name}"
-    resource_group_name_service_health_alerts   = "$${service_health_alerts_resource_group_name}"
-    resource_group_name_mdfc                    = "$${asc_export_resource_group_name}"
-    resource_group_location                     = "$${starter_location_01}"
-    email_security_contact                      = "$${defender_email_security_contact}"
+    #ddos_protection_plan_id                     = "$${ddos_protection_plan_id}"
+    #private_dns_zone_subscription_id            = "$${subscription_id_connectivity}"
+    #private_dns_zone_region                     = "$${starter_location_01}"
+    #private_dns_zone_resource_group_name        = "$${dns_resource_group_name}"
+    resource_group_name_service_health_alerts = "$${service_health_alerts_resource_group_name}"
+    resource_group_name_mdfc                  = "$${asc_export_resource_group_name}"
+    resource_group_location                   = "$${starter_location_01}"
+    email_security_contact                    = "$${defender_email_security_contact}"
   }
   subscription_placement = {
     # Uncomment the identity block below when you have a dedicated identity subscription
@@ -252,6 +257,13 @@ You can use this section to customize the hub virtual networking that will be de
 connectivity_type = "hub_and_spoke_vnet"
 
 connectivity_resource_groups = {
+  ddos = {
+    name     = "$${ddos_resource_group_name}"
+    location = "$${starter_location_01}"
+    settings = {
+      enabled = "$${ddos_protection_plan_enabled}"
+    }
+  }
   vnet_primary = {
     name     = "$${connectivity_hub_primary_resource_group_name}"
     location = "$${starter_location_01}"
@@ -271,6 +283,11 @@ connectivity_resource_groups = {
 hub_and_spoke_networks_settings = {
   enabled_resources = {
     ddos_protection_plan = "$${ddos_protection_plan_enabled}"
+  }
+  ddos_protection_plan = {
+    name                = "$${ddos_protection_plan_name}"
+    resource_group_name = "$${ddos_resource_group_name}"
+    location            = "$${starter_location_01}"
   }
 }
 

--- a/templates/platform_landing_zone/examples/smb-single-region/virtual-wan.tfvars
+++ b/templates/platform_landing_zone/examples/smb-single-region/virtual-wan.tfvars
@@ -64,11 +64,13 @@ custom_replacements = {
     connectivity_hub_vwan_resource_group_name    = "rg-hub-vwan-$${starter_location_01}"
     connectivity_hub_primary_resource_group_name = "rg-hub-$${starter_location_01}"
     dns_resource_group_name                      = "rg-hub-dns-$${starter_location_01}"
+    ddos_resource_group_name                     = "rg-hub-ddos-$${starter_location_01}"
     asc_export_resource_group_name               = "rg-asc-export-$${starter_location_01}"
     service_health_alerts_resource_group_name    = "rg-service-health-alerts-$${starter_location_01}"
 
     # Resource names
     log_analytics_workspace_name            = "law-management-$${starter_location_01}"
+    ddos_protection_plan_name               = "ddos-$${starter_location_01}"
     ama_user_assigned_managed_identity_name = "uami-management-ama-$${starter_location_01}"
     dcr_change_tracking_name                = "dcr-change-tracking"
     dcr_defender_sql_name                   = "dcr-defender-sql"
@@ -87,6 +89,7 @@ custom_replacements = {
   */
   resource_group_identifiers = {
     management_resource_group_id           = "/subscriptions/$${subscription_id_management}/resourcegroups/$${management_resource_group_name}"
+    ddos_protection_plan_resource_group_id = "/subscriptions/$${subscription_id_connectivity}/resourcegroups/$${ddos_resource_group_name}"
     primary_connectivity_resource_group_id = "/subscriptions/$${subscription_id_connectivity}/resourceGroups/$${connectivity_hub_primary_resource_group_name}"
     dns_resource_group_id                  = "/subscriptions/$${subscription_id_connectivity}/resourceGroups/$${dns_resource_group_name}"
   }
@@ -103,6 +106,7 @@ custom_replacements = {
     ama_vm_insights_data_collection_rule_id     = "$${management_resource_group_id}/providers/Microsoft.Insights/dataCollectionRules/$${dcr_vm_insights_name}"
     ama_user_assigned_managed_identity_id       = "$${management_resource_group_id}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$${ama_user_assigned_managed_identity_name}"
     log_analytics_workspace_id                  = "$${management_resource_group_id}/providers/Microsoft.OperationalInsights/workspaces/$${log_analytics_workspace_name}"
+    ddos_protection_plan_id                     = "$${ddos_protection_plan_resource_group_id}/providers/Microsoft.Network/ddosProtectionPlans/$${ddos_protection_plan_name}"
   }
 }
 
@@ -163,13 +167,14 @@ management_group_settings = {
     ama_user_assigned_managed_identity_id       = "$${ama_user_assigned_managed_identity_id}"
     ama_user_assigned_managed_identity_name     = "$${ama_user_assigned_managed_identity_name}"
     log_analytics_workspace_id                  = "$${log_analytics_workspace_id}"
-    private_dns_zone_subscription_id            = "$${subscription_id_connectivity}"
-    private_dns_zone_region                     = "$${starter_location_01}"
-    private_dns_zone_resource_group_name        = "$${dns_resource_group_name}"
-    resource_group_name_service_health_alerts   = "$${service_health_alerts_resource_group_name}"
-    resource_group_name_mdfc                    = "$${asc_export_resource_group_name}"
-    resource_group_location                     = "$${starter_location_01}"
-    email_security_contact                      = "$${defender_email_security_contact}"
+    #ddos_protection_plan_id                     = "$${ddos_protection_plan_id}"
+    #private_dns_zone_subscription_id            = "$${subscription_id_connectivity}"
+    #private_dns_zone_region                     = "$${starter_location_01}"
+    #private_dns_zone_resource_group_name        = "$${dns_resource_group_name}"
+    resource_group_name_service_health_alerts = "$${service_health_alerts_resource_group_name}"
+    resource_group_name_mdfc                  = "$${asc_export_resource_group_name}"
+    resource_group_location                   = "$${starter_location_01}"
+    email_security_contact                    = "$${defender_email_security_contact}"
   }
   subscription_placement = {
     # Uncomment the identity block below when you have a dedicated identity subscription
@@ -254,6 +259,13 @@ You can use this section to customize the virtual wan networking that will be de
 connectivity_type = "virtual_wan"
 
 connectivity_resource_groups = {
+  ddos = {
+    name     = "$${ddos_resource_group_name}"
+    location = "$${starter_location_01}"
+    settings = {
+      enabled = "$${ddos_protection_plan_enabled}"
+    }
+  }
   vwan = {
     name     = "$${connectivity_hub_vwan_resource_group_name}"
     location = "$${starter_location_01}"
@@ -284,6 +296,11 @@ virtual_wan_settings = {
   virtual_wan = {
     name                = "vwan-$${starter_location_01}"
     resource_group_name = "$${connectivity_hub_vwan_resource_group_name}"
+    location            = "$${starter_location_01}"
+  }
+  ddos_protection_plan = {
+    name                = "$${ddos_protection_plan_name}"
+    resource_group_name = "$${ddos_resource_group_name}"
     location            = "$${starter_location_01}"
   }
 }


### PR DESCRIPTION
## Summary

Adds DDoS protection plan resource group, naming, and configuration to the SMB single-region examples for both hub-and-spoke VNet and Virtual WAN topologies.

Relates to Azure/Azure-Landing-Zones#4108

## Changes

- Add `ddos_resource_group_name` and `ddos_protection_plan_name` custom replacements
- Add `ddos_protection_plan_resource_group_id` resource group identifier
- Add `ddos_protection_plan_id` resource identifier
- Add `ddos` resource group to `connectivity_resource_groups` (gated by `ddos_protection_plan_enabled`)
- Add `ddos_protection_plan` settings block to both `hub_and_spoke_networks_settings` and `virtual_wan_settings`
- Comment out DDoS and private DNS zone policy assignment parameters pending upstream support

## Files Modified

- `templates/platform_landing_zone/examples/smb-single-region/hub-and-spoke-vnet.tfvars`
- `templates/platform_landing_zone/examples/smb-single-region/virtual-wan.tfvars`