### PR TITLE
feat: update libs to latest

### DIFF
--- a/templates/platform_landing_zone/examples/slz/lib/alz_library_metadata.json
+++ b/templates/platform_landing_zone/examples/slz/lib/alz_library_metadata.json
@@ -6,7 +6,7 @@
   "dependencies": [
     {
       "path": "platform/slz",
-      "ref": "2026.02.2"
+      "ref": "2026.04.0"
     }
   ]
 }

--- a/templates/platform_landing_zone/lib/alz_library_metadata.json
+++ b/templates/platform_landing_zone/lib/alz_library_metadata.json
@@ -6,7 +6,7 @@
   "dependencies": [
     {
       "path": "platform/alz",
-      "ref": "2026.01.3"
+      "ref": "2026.04.0"
     }
   ]
 }

--- a/templates/test/lib/alz_library_metadata.json
+++ b/templates/test/lib/alz_library_metadata.json
@@ -6,7 +6,7 @@
   "dependencies": [
     {
       "path": "platform/alz",
-      "ref": "2025.09.3"
+      "ref": "2026.04.0"
     }
   ]
 }


### PR DESCRIPTION
This pull request updates dependency references in several `alz_library_metadata.json` files to use the latest versions of their respective modules. These changes help ensure that the platform landing zone and test templates are using the most up-to-date and compatible versions.

Dependency version updates:

* Updated the `platform/slz` dependency reference to `2026.04.0` in `templates/platform_landing_zone/examples/slz/lib/alz_library_metadata.json`
* Updated the `platform/alz` dependency reference to `2026.04.0` in both `templates/platform_landing_zone/lib/alz_library_metadata.json` and `templates/test/lib/alz_library_metadata.json`