### PR TITLE
feat(slz): add sovereign_l1/l2/l3 controls archetype overrides

### DIFF
--- a/templates/platform_landing_zone/examples/slz/lib/alz_library_metadata.json
+++ b/templates/platform_landing_zone/examples/slz/lib/alz_library_metadata.json
@@ -6,7 +6,7 @@
   "dependencies": [
     {
       "path": "platform/slz",
-      "ref": "2026.04.1"
+      "ref": "2026.04.2"
     }
   ]
 }

--- a/templates/platform_landing_zone/examples/slz/lib/alz_library_metadata.json
+++ b/templates/platform_landing_zone/examples/slz/lib/alz_library_metadata.json
@@ -6,7 +6,7 @@
   "dependencies": [
     {
       "path": "platform/slz",
-      "ref": "2026.04.0"
+      "ref": "2026.04.1"
     }
   ]
 }

--- a/templates/platform_landing_zone/examples/slz/lib/archetype_definitions/sovereign_l1_controls_custom.alz_archetype_override.yaml
+++ b/templates/platform_landing_zone/examples/slz/lib/archetype_definitions/sovereign_l1_controls_custom.alz_archetype_override.yaml
@@ -1,10 +1,7 @@
-base_archetype: confidential_corp
-name: confidential_corp_custom
+base_archetype: sovereign_l1_controls
+name: sovereign_l1_controls_custom
 policy_assignments_to_add: []
-policy_assignments_to_remove: [
-# To remove the private DNS zones policy for private endpoints
-  # Deploy-Private-DNS-Zones,
-]
+policy_assignments_to_remove: []
 policy_definitions_to_add: []
 policy_definitions_to_remove: []
 policy_set_definitions_to_add: []

--- a/templates/platform_landing_zone/examples/slz/lib/archetype_definitions/sovereign_l2_controls_custom.alz_archetype_override.yaml
+++ b/templates/platform_landing_zone/examples/slz/lib/archetype_definitions/sovereign_l2_controls_custom.alz_archetype_override.yaml
@@ -1,0 +1,10 @@
+base_archetype: sovereign_l2_controls
+name: sovereign_l2_controls_custom
+policy_assignments_to_add: []
+policy_assignments_to_remove: []
+policy_definitions_to_add: []
+policy_definitions_to_remove: []
+policy_set_definitions_to_add: []
+policy_set_definitions_to_remove: []
+role_definitions_to_add: []
+role_definitions_to_remove: []

--- a/templates/platform_landing_zone/examples/slz/lib/archetype_definitions/sovereign_l3_controls_custom.alz_archetype_override.yaml
+++ b/templates/platform_landing_zone/examples/slz/lib/archetype_definitions/sovereign_l3_controls_custom.alz_archetype_override.yaml
@@ -1,5 +1,5 @@
-base_archetype: confidential_online
-name: confidential_online_custom
+base_archetype: sovereign_l3_controls
+name: sovereign_l3_controls_custom
 policy_assignments_to_add: []
 policy_assignments_to_remove: []
 policy_definitions_to_add: []

--- a/templates/platform_landing_zone/examples/slz/lib/architecture_definitions/alz_custom.alz_architecture_definition.yaml
+++ b/templates/platform_landing_zone/examples/slz/lib/architecture_definitions/alz_custom.alz_architecture_definition.yaml
@@ -4,7 +4,7 @@ management_groups:
     display_name: Sovereign Landing Zone
     archetypes:
       - root_custom
-      - sovereign_root_custom
+      - sovereign_l1_controls_custom
     exists: false
     parent_id: null
 
@@ -33,6 +33,7 @@ management_groups:
     display_name: Corp
     archetypes:
       - corp_custom
+      - sovereign_l2_controls_custom
     exists: false
     parent_id: landingzones
 
@@ -40,6 +41,14 @@ management_groups:
     display_name: Online
     archetypes:
       - online_custom
+      - sovereign_l2_controls_custom
+    exists: false
+    parent_id: landingzones
+
+  - id: local
+    display_name: Local
+    archetypes:
+      - local_custom
     exists: false
     parent_id: landingzones
 
@@ -47,7 +56,8 @@ management_groups:
     display_name: Confidential Corp
     archetypes:
       - corp_custom
-      - confidential_corp_custom
+      - sovereign_l2_controls_custom
+      - sovereign_l3_controls_custom
     exists: false
     parent_id: landingzones
 
@@ -55,7 +65,8 @@ management_groups:
     display_name: Confidential Online
     archetypes:
       - online_custom
-      - confidential_online_custom
+      - sovereign_l2_controls_custom
+      - sovereign_l3_controls_custom
     exists: false
     parent_id: landingzones
 
@@ -70,6 +81,7 @@ management_groups:
     display_name: Security
     archetypes:
       - security_custom
+      - sovereign_l2_controls_custom
     exists: false
     parent_id: platform
 
@@ -77,6 +89,7 @@ management_groups:
     display_name: Management
     archetypes:
       - management_custom
+      - sovereign_l2_controls_custom
     exists: false
     parent_id: platform
 
@@ -84,6 +97,7 @@ management_groups:
     display_name: Connectivity
     archetypes:
       - connectivity_custom
+      - sovereign_l2_controls_custom
     exists: false
     parent_id: platform
 
@@ -91,6 +105,7 @@ management_groups:
     display_name: Identity
     archetypes:
       - identity_custom
+      - sovereign_l2_controls_custom
     exists: false
     parent_id: platform
 

--- a/templates/platform_landing_zone/lib/alz_library_metadata.json
+++ b/templates/platform_landing_zone/lib/alz_library_metadata.json
@@ -6,7 +6,7 @@
   "dependencies": [
     {
       "path": "platform/alz",
-      "ref": "2026.04.0"
+      "ref": "2026.04.1"
     }
   ]
 }

--- a/templates/platform_landing_zone/lib/alz_library_metadata.json
+++ b/templates/platform_landing_zone/lib/alz_library_metadata.json
@@ -6,7 +6,7 @@
   "dependencies": [
     {
       "path": "platform/alz",
-      "ref": "2026.04.1"
+      "ref": "2026.04.2"
     }
   ]
 }

--- a/templates/platform_landing_zone/lib/archetype_definitions/local_custom.alz_archetype_override.yaml
+++ b/templates/platform_landing_zone/lib/archetype_definitions/local_custom.alz_archetype_override.yaml
@@ -1,5 +1,5 @@
-base_archetype: sovereign_root
-name: sovereign_root_custom
+base_archetype: local
+name: local_custom
 policy_assignments_to_add: []
 policy_assignments_to_remove: []
 policy_definitions_to_add: []

--- a/templates/platform_landing_zone/lib/architecture_definitions/alz_custom.alz_architecture_definition.yaml
+++ b/templates/platform_landing_zone/lib/architecture_definitions/alz_custom.alz_architecture_definition.yaml
@@ -35,6 +35,13 @@ management_groups:
     exists: false
     parent_id: landingzones
 
+  - id: local
+    display_name: Local
+    archetypes:
+      - local_custom
+    exists: false
+    parent_id: landingzones
+
   - id: sandbox
     display_name: Sandbox
     archetypes:


### PR DESCRIPTION
Adds the missing `sovereign_l1_controls_custom`, `sovereign_l2_controls_custom`, and `sovereign_l3_controls_custom` archetype override files for the SLZ example, plus related architecture/library updates.