### PR TITLE
feat(connectivity): bump connectivity AVM modules and sync interfaces

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
         with:
-          terraform_version: latest
+          terraform_version: 1.14.9
           terraform_wrapper: false
 
       - name: Setup Module Inputs

--- a/.github/workflows/fmt-test.yml
+++ b/.github/workflows/fmt-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
-          terraform_version: latest
+          terraform_version: 1.14.9
           terraform_wrapper: false
 
       - name: Check fmt

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
         with:
-          terraform_version: latest
+          terraform_version: 1.14.9
           terraform_wrapper: false
 
       - name: Setup Module Inputs

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: latest
+          terraform_version: 1.14.9
           terraform_wrapper: false
 
       - name: Checkout code

--- a/templates/platform_landing_zone/main.connectivity.hub.and.spoke.virtual.network.tf
+++ b/templates/platform_landing_zone/main.connectivity.hub.and.spoke.virtual.network.tf
@@ -1,6 +1,6 @@
 module "hub_and_spoke_vnet" {
   source  = "Azure/avm-ptn-alz-connectivity-hub-and-spoke-vnet/azurerm"
-  version = "0.16.14"
+  version = "0.17.1"
 
   count = local.connectivity_hub_and_spoke_vnet_enabled ? 1 : 0
 

--- a/templates/platform_landing_zone/main.connectivity.virtual.wan.tf
+++ b/templates/platform_landing_zone/main.connectivity.virtual.wan.tf
@@ -1,6 +1,6 @@
 module "virtual_wan" {
   source  = "Azure/avm-ptn-alz-connectivity-virtual-wan/azurerm"
-  version = "0.14.0"
+  version = "0.15.0"
 
   count = local.connectivity_virtual_wan_enabled ? 1 : 0
 

--- a/templates/platform_landing_zone/outputs.moved.tf
+++ b/templates/platform_landing_zone/outputs.moved.tf
@@ -1,12 +1,12 @@
-output "private_link_private_dns_zone_virtual_network_link_moved_block_template_module_prefix" {
+output "private_link_private_dns_zone_virtual_network_link_moved_blocks" {
   description = <<DESCRIPTION
-The module prefix for the Private Link Private DNS Zone Virtual Network Link moved block template.
+Moved blocks for the Private Link Private DNS Zone Virtual Network Links.
 
 NOTE: This is a temporary output to support migration to the new module and will be removed in the next major version.
 DESCRIPTION
   value = (var.private_link_private_dns_zone_virtual_network_link_moved_blocks_enabled && local.connectivity_enabled ?
     (local.connectivity_virtual_wan_enabled ?
-      module.virtual_wan[0].private_link_private_dns_zone_virtual_network_link_moved_block_template_module_prefix :
-    module.hub_and_spoke_vnet[0].private_link_private_dns_zone_virtual_network_link_moved_block_template_module_prefix)
+      module.virtual_wan[0].private_link_private_dns_zone_virtual_network_link_moved_blocks :
+    module.hub_and_spoke_vnet[0].private_link_private_dns_zone_virtual_network_link_moved_blocks)
   : null)
 }

--- a/templates/platform_landing_zone/outputs.tf
+++ b/templates/platform_landing_zone/outputs.tf
@@ -50,6 +50,70 @@ output "hub_and_spoke_vnet_route_tables_user_subnets" {
   value = local.connectivity_hub_and_spoke_vnet_enabled ? module.hub_and_spoke_vnet[0].route_tables_user_subnets : null
 }
 
+output "hub_and_spoke_vnet_route_tables_gateway_resource_ids" {
+  value = local.connectivity_hub_and_spoke_vnet_enabled ? module.hub_and_spoke_vnet[0].route_tables_gateway_resource_ids : null
+}
+
+output "hub_and_spoke_vnet_ddos_protection_plan_resource_id" {
+  value = local.connectivity_hub_and_spoke_vnet_enabled ? module.hub_and_spoke_vnet[0].ddos_protection_plan_resource_id : null
+}
+
+output "hub_and_spoke_vnet_nat_gateway_resource_ids" {
+  value = local.connectivity_hub_and_spoke_vnet_enabled ? module.hub_and_spoke_vnet[0].nat_gateway_resource_ids : null
+}
+
+output "hub_and_spoke_vnet_nat_gateways" {
+  value = local.connectivity_hub_and_spoke_vnet_enabled ? module.hub_and_spoke_vnet[0].nat_gateways : null
+}
+
+output "hub_and_spoke_vnet_virtual_network_gateway_resource_ids" {
+  value = local.connectivity_hub_and_spoke_vnet_enabled ? module.hub_and_spoke_vnet[0].virtual_network_gateway_resource_ids : null
+}
+
+output "hub_and_spoke_vnet_virtual_network_gateway_public_ip_addresses" {
+  value = local.connectivity_hub_and_spoke_vnet_enabled ? module.hub_and_spoke_vnet[0].virtual_network_gateway_public_ip_addresses : null
+}
+
+output "hub_and_spoke_vnet_virtual_network_gateway_public_ip_resource_ids" {
+  value = local.connectivity_hub_and_spoke_vnet_enabled ? module.hub_and_spoke_vnet[0].virtual_network_gateway_public_ip_resource_ids : null
+}
+
+output "hub_and_spoke_vnet_virtual_network_gateway_local_network_gateway_resource_ids" {
+  value = local.connectivity_hub_and_spoke_vnet_enabled ? module.hub_and_spoke_vnet[0].virtual_network_gateway_local_network_gateway_resource_ids : null
+}
+
+output "hub_and_spoke_vnet_virtual_network_gateway_local_network_gateway_connection_resource_ids" {
+  value = local.connectivity_hub_and_spoke_vnet_enabled ? module.hub_and_spoke_vnet[0].virtual_network_gateway_local_network_gateway_connection_resource_ids : null
+}
+
+output "hub_and_spoke_vnet_virtual_network_gateway_express_route_circuit_connection_resource_ids" {
+  value = local.connectivity_hub_and_spoke_vnet_enabled ? module.hub_and_spoke_vnet[0].virtual_network_gateway_express_route_circuit_connection_resource_ids : null
+}
+
+output "hub_and_spoke_vnet_bastion_host_public_ip_resource_ids" {
+  value = local.connectivity_hub_and_spoke_vnet_enabled ? module.hub_and_spoke_vnet[0].bastion_host_public_ip_resource_ids : null
+}
+
+output "hub_and_spoke_vnet_dns_resolver_resource_ids" {
+  value = local.connectivity_hub_and_spoke_vnet_enabled ? module.hub_and_spoke_vnet[0].dns_resolver_resource_ids : null
+}
+
+output "hub_and_spoke_vnet_dns_resolver_inbound_endpoint_ip_addresses" {
+  value = local.connectivity_hub_and_spoke_vnet_enabled ? module.hub_and_spoke_vnet[0].dns_resolver_inbound_endpoint_ip_addresses : null
+}
+
+output "hub_and_spoke_vnet_private_dns_zone_resource_ids" {
+  value = local.connectivity_hub_and_spoke_vnet_enabled ? module.hub_and_spoke_vnet[0].private_dns_zone_resource_ids : null
+}
+
+output "hub_and_spoke_vnet_private_dns_zone_auto_registration_resource_ids" {
+  value = local.connectivity_hub_and_spoke_vnet_enabled ? module.hub_and_spoke_vnet[0].private_dns_zone_auto_registration_resource_ids : null
+}
+
+output "hub_and_spoke_vnet_private_link_private_dns_zones_maps" {
+  value = local.connectivity_hub_and_spoke_vnet_enabled ? module.hub_and_spoke_vnet[0].private_link_private_dns_zones_maps : null
+}
+
 output "hub_and_spoke_vnet_full_output" {
   value = local.connectivity_hub_and_spoke_vnet_enabled ? module.hub_and_spoke_vnet[0] : null
 }
@@ -120,6 +184,22 @@ output "virtual_wan_sidecar_virtual_network_resource_ids" {
 
 output "virtual_wan_sidecar_virtual_network_resources" {
   value = local.connectivity_virtual_wan_enabled ? module.virtual_wan[0].sidecar_virtual_network_resources : null
+}
+
+output "virtual_wan_virtual_hub_bgp_connection_resource_ids" {
+  value = local.connectivity_virtual_wan_enabled ? module.virtual_wan[0].virtual_hub_bgp_connection_resource_ids : null
+}
+
+output "virtual_wan_express_route_gateway_resources" {
+  value = local.connectivity_virtual_wan_enabled ? module.virtual_wan[0].express_route_gateway_resources : null
+}
+
+output "virtual_wan_private_dns_zone_resource_ids" {
+  value = local.connectivity_virtual_wan_enabled ? module.virtual_wan[0].private_dns_zone_resource_ids : null
+}
+
+output "virtual_wan_private_link_private_dns_zones_maps" {
+  value = local.connectivity_virtual_wan_enabled ? module.virtual_wan[0].private_link_private_dns_zones_maps : null
 }
 
 output "virtual_wan_full_output" {

--- a/templates/platform_landing_zone/variables.connectivity.hub.and.spoke.virtual.network.tf
+++ b/templates/platform_landing_zone/variables.connectivity.hub.and.spoke.virtual.network.tf
@@ -38,6 +38,7 @@ variable "hub_virtual_networks" {
       virtual_network_gateway_vpn           = optional(any, true)
       private_dns_zones                     = optional(any, true)
       private_dns_resolver                  = optional(any, true)
+      nat_gateway                           = optional(any, false)
     }), {})
 
     default_hub_address_space = optional(string)
@@ -83,7 +84,8 @@ variable "hub_virtual_networks" {
           name             = string
           address_prefixes = list(string)
           nat_gateway = optional(object({
-            id = string
+            id                           = optional(string)
+            assign_generated_nat_gateway = optional(bool, false)
           }))
           network_security_group = optional(object({
             id = string
@@ -93,6 +95,7 @@ variable "hub_virtual_networks" {
           route_table = optional(object({
             id                           = optional(string)
             assign_generated_route_table = optional(bool, true)
+            route_table_reference_key    = optional(string, "UserSubnets")
           }))
           service_endpoints_with_location = optional(list(object({
             service   = string
@@ -115,6 +118,38 @@ variable "hub_virtual_networks" {
       )), {})
     }), {})
 
+    nat_gateway = optional(object({
+      name                    = optional(string)
+      parent_id               = optional(string)
+      location                = optional(string)
+      sku                     = optional(string, "StandardV2")
+      idle_timeout_in_minutes = optional(number, 4)
+      tags                    = optional(map(string), null)
+      zones                   = optional(set(string))
+      lock = optional(object({
+        kind = string
+        name = optional(string)
+      }))
+      ip_configurations = optional(map(object({
+        is_default                 = optional(bool, false)
+        name                       = optional(string)
+        public_ip_creation_enabled = optional(bool, true)
+        public_ip_configuration = optional(object({
+          ip_version                     = optional(string, "IPv4")
+          name                           = optional(string)
+          public_ip_existing_resource_id = optional(string)
+          sku                            = optional(string, "StandardV2")
+          sku_tier                       = optional(string, "Regional")
+          zones                          = optional(set(string))
+          allocation_method              = optional(string, "Static")
+          public_ip_prefix_id            = optional(string)
+          domain_name_label              = optional(string)
+          idle_timeout_in_minutes        = optional(number, 4)
+          ddos_protection_mode           = optional(string, "VirtualNetworkInherited")
+        }), {})
+      })), {})
+    }), {})
+
     firewall = optional(object({
       name                                              = optional(string)
       resource_group_name                               = optional(string)
@@ -130,6 +165,10 @@ variable "hub_virtual_networks" {
       subnet_route_table_id                             = optional(string)
       tags                                              = optional(map(string))
       zones                                             = optional(list(string))
+      firewall_subnet_nat_gateway = optional(object({
+        id                           = optional(string, null)
+        assign_generated_nat_gateway = optional(bool, false)
+      }))
 
       default_ip_configuration = optional(object({
         is_default = optional(bool, true)
@@ -415,7 +454,7 @@ variable "hub_virtual_networks" {
         parent_id                             = optional(string)
         sku                                   = optional(string, "VpnGw1AZ")
         edge_zone                             = optional(string)
-        hosted_on_behalf_of_public_ip_enabled = optional(bool, false)
+        hosted_on_behalf_of_public_ip_enabled = optional(any, false)
         ip_configurations = optional(map(object({
           name                          = optional(string, null)
           apipa_addresses               = optional(list(string), null)
@@ -688,6 +727,7 @@ The following top level attributes are supported:
     - `virtual_network_gateway_vpn` - (Optional) Should the VPN gateway be created? Default `true`.
     - `private_dns_zones` - (Optional) Should private DNS zones be created? Default `true`.
     - `private_dns_resolver` - (Optional) Should the private DNS resolver be created? Default `true`.
+    - `nat_gateway` - (Optional) Should the NAT Gateway be created? Default `true`.
   - `default_hub_address_space` - (Optional) The default address space to use if not specified in hub_virtual_network. This defaults to `10.0.0.0/16` and increments to the next /16 for each region if not supplied.
   - `default_parent_id` - (Optional) The default parent resource group ID to use if not specified in hub_virtual_network or individual sections.
   - `location` - (Required) The Azure location where the hub network resources should be created.
@@ -696,6 +736,7 @@ The following top level attributes are supported:
   - `firewall_policy` - (Optional) The firewall policy settings.
   - `bastion` - (Optional) The bastion host settings.
   - `virtual_network_gateways` - (Optional) The virtual network gateway settings.
+  - `nat_gateway` - (Optional) The NAT Gateway settings.
   - `private_dns_zones` - (Optional) The private DNS zone settings.
   - `private_dns_resolver` - (Optional) The private DNS resolver settings.
 
@@ -735,6 +776,7 @@ The following top level attributes are supported:
     - `address_prefixes` - The IPv4 address prefixes to use for the subnet in CIDR format.
     - `nat_gateway` - (Optional) An object with the following fields:
       - `id` - The ID of the NAT Gateway which should be associated with the Subnet. Changing this forces a new resource to be created.
+      - `assign_generated_nat_gateway` - (Optional) Should the NAT Gateway generated by this module be associated with this Subnet? Default `false`.
     - `network_security_group` - (Optional) An object with the following fields:
       - `id` - The ID of the Network Security Group which should be associated with the Subnet. Changing this forces a new association to be created.
     - `private_endpoint_network_policies_enabled` - (Optional) Enable or Disable network policies for the private endpoint on the subnet. Setting this to true will Enable the policy and setting this to false will Disable the policy. Defaults to true.
@@ -742,6 +784,7 @@ The following top level attributes are supported:
     - `route_table` - (Optional) An object with the following fields which are mutually exclusive, choose either an external route table or the generated route table:
       - `id` - The ID of the Route Table which should be associated with the Subnet. Changing this forces a new association to be created.
       - `assign_generated_route_table` - (Optional) Should the Route Table generated by this module be associated with this Subnet? Default `true`.
+      - `route_table_reference_key` - (Optional) The key of the Route Table to reference if using the generated Route Table. This is used to link the subnet to the correct Route Table when multiple Route Tables are generated. Possible values are 'Firewall' or 'UserSubnets'. Defaults to 'UserSubnets'.
     - `service_endpoints_with_location` - (Optional) The list of Service endpoints to associate with the subnet.
     - `service_endpoint_policy_ids` - (Optional) The list of Service Endpoint Policy IDs to associate with the subnet.
     - `delegations` - (Optional) A list of delegation objects with the following fields:
@@ -779,8 +822,8 @@ The following top level attributes are supported:
       - `sku_tier` - (Optional) The SKU tier to use for the public IP configuration. Possible values include `Regional`, `Global`. If not specified will be `Regional`.
       - `domain_name_label` - (Optional) The domain name label for the public IP configuration.
       - `public_ip_prefix_id` - (Optional) The ID of the public IP prefix.
-      - `ddos_protection_mode` - (Optional) The DDoS protection mode. Default `VirtualNetworkInherited`. Possible values are `Disabled`, `Enabled`, `VirtualNetworkInherited`.
-      - `ddos_protection_plan_id` - (Optional) The DDoS protection plan ID.
+      - `ddos_protection_mode` - (Optional) The DDoS protection mode. Default `VirtualNetworkInherited`. For IP plan use Enabled. Possible values are Disabled, Enabled, VirtualNetworkInherited
+      - `ddos_protection_plan_id` - (Optional) The DDoS protection plan ID. For IP plan do not create ddos plan, nor send in id here
   - `ip_configurations` - (Optional) A map of the default IP configuration for the Azure Firewall. If not specified the defaults below will be used:
     - `name` - (Optional) The name of the default IP configuration. If not specified will use `default`.
     - `is_default` - (Optional) Indicates this is the default IP configuration, which will be linked to the Firewall subnet. If not specified will be `false`. At least one and only one IP configuration must have this set to `true`.
@@ -792,8 +835,8 @@ The following top level attributes are supported:
       - `sku_tier` - (Optional) The SKU tier to use for the public IP configuration. Possible values include `Regional`, `Global`. If not specified will be `Regional`.
       - `domain_name_label` - (Optional) The domain name label for the public IP configuration.
       - `public_ip_prefix_id` - (Optional) The ID of the public IP prefix.
-      - `ddos_protection_mode` - (Optional) The DDoS protection mode. Default `VirtualNetworkInherited`. Possible values are `Disabled`, `Enabled`, `VirtualNetworkInherited`.
-      - `ddos_protection_plan_id` - (Optional) The DDoS protection plan ID.
+      - `ddos_protection_mode` - (Optional) The DDoS protection mode. Default `VirtualNetworkInherited`. For IP plan use Enabled. Possible values are Disabled, Enabled, VirtualNetworkInherited
+      - `ddos_protection_plan_id` - (Optional) The DDoS protection plan ID. For IP plan do not create ddos plan, nor send in id here
   - `management_ip_configuration` - (Optional) An object with the following fields. If not specified the defaults below will be used:
     - `name` - (Optional) The name of the management IP configuration. If not specified will use `defaultMgmt`.
     - `public_ip_config` - (Optional) An object with the following fields:
@@ -804,8 +847,8 @@ The following top level attributes are supported:
       - `sku_tier` - (Optional) The SKU tier to use for the public IP configuration. Possible values include `Regional`, `Global`. If not specified will be `Regional`.
       - `domain_name_label` - (Optional) The domain name label for the public IP configuration.
       - `public_ip_prefix_id` - (Optional) The ID of the public IP prefix.
-      - `ddos_protection_mode` - (Optional) The DDoS protection mode. Default `VirtualNetworkInherited`. Possible values are `Disabled`, `Enabled`, `VirtualNetworkInherited`.
-      - `ddos_protection_plan_id` - (Optional) The DDoS protection plan ID.
+      - `ddos_protection_mode` - (Optional) The DDoS protection mode. Default `VirtualNetworkInherited`. For IP plan use Enabled. Possible values are Disabled, Enabled, VirtualNetworkInherited
+      - `ddos_protection_plan_id` - (Optional) The DDoS protection plan ID. For IP plan do not create ddos plan, nor send in id here
 
 ## Azure Firewall Policy
 
@@ -895,6 +938,36 @@ The following top level attributes are supported:
     - `ddos_protection_mode` - (Optional) The DDoS protection mode. Possible values are `Disabled`, `Enabled`, `VirtualNetworkInherited`. Default `VirtualNetworkInherited`.
     - `ddos_protection_plan_id` - (Optional) The ID of the DDoS protection plan.
     - `resource_group_name` - (Optional) The name of the resource group where the public IP should be created. If not specified will use the bastion resource group name or the parent resource group of the virtual network.
+
+## NAT Gateway
+
+- `nat_gateway` - (Optional) An object with the following fields:
+  - `name` - (Optional) The name of the NAT Gateway resource.
+  - `parent_id` - (Optional) The ID of the parent resource group where the NAT Gateway should be created.
+  - `location` - (Optional) The Azure location where the NAT Gateway should be created. If not specified, uses the hub's location.
+  - `sku` - (Optional) The SKU of the NAT Gateway. Default `StandardV2`.
+  - `idle_timeout_in_minutes` - (Optional) The idle timeout in minutes for the NAT Gateway. Default `4`.
+  - `tags` - (Optional) A map of tags to apply to the NAT Gateway.
+  - `zones` - (Optional) A set of availability zones for the NAT Gateway.
+  - `lock` - (Optional) An object for resource lock configuration with:
+    - `kind` - (Required) The type of lock. Possible values are `CanNotDelete` and `ReadOnly`.
+    - `name` - (Optional) The name of the lock.
+  - `ip_configurations` - (Optional) A map of IP configurations for the NAT Gateway. Maximum 16 configurations are supported. Each configuration is an object with:
+    - `is_default` - (Optional) Is this the default IP configuration? Default `false`.
+    - `name` - (Optional) The name of the IP configuration.
+    - `public_ip_creation_enabled` - (Optional) Should a public IP be created for this configuration? Default `true`.
+    - `public_ip_configuration` - (Optional) An object with the following fields:
+      - `ip_version` - (Optional) The IP version. Possible values are `IPv4`, `IPv6`. Default `IPv4`.
+      - `name` - (Optional) The name of the public IP.
+      - `public_ip_existing_resource_id` - (Optional) The resource ID of an existing public IP to use instead of creating a new one.
+      - `sku` - (Optional) The SKU of the public IP. Default `StandardV2`. Required for StandardV2 NAT Gateway with availability zones support.
+      - `sku_tier` - (Optional) The SKU tier of the public IP. Possible values are `Regional`, `Global`. Default `Regional`.
+      - `zones` - (Optional) A set of availability zones for the public IP.
+      - `allocation_method` - (Optional) The allocation method for the public IP. Possible values are `Static`, `Dynamic`. Default `Static`.
+      - `public_ip_prefix_id` - (Optional) The ID of the public IP prefix.
+      - `domain_name_label` - (Optional) The domain name label for the public IP.
+      - `idle_timeout_in_minutes` - (Optional) The idle timeout in minutes for the public IP. Default `4`.
+      - `ddos_protection_mode` - (Optional) The DDoS protection mode. Possible values are `Disabled`, `Enabled`, `VirtualNetworkInherited`. Default `VirtualNetworkInherited`.
 
 ## Virtual Network Gateways
 
@@ -1238,4 +1311,53 @@ The following top level attributes are supported:
   - `tags` - (Optional) A map of tags to apply to the DNS resolver.
 
 DESCRIPTION
+
+  validation {
+    condition = alltrue([
+      for hub_key, hub in var.hub_virtual_networks :
+      hub.nat_gateway == null ? true : alltrue([
+        for ip_config_key, ip_config in coalesce(hub.nat_gateway.ip_configurations, {}) :
+        ip_config.public_ip_creation_enabled != false || (
+          ip_config.public_ip_configuration != null && ip_config.public_ip_configuration.public_ip_existing_resource_id != null
+        )
+      ])
+    ])
+    error_message = "When public_ip_creation_enabled is set to false for a NAT gateway IP configuration, public_ip_existing_resource_id must be provided."
+  }
+  validation {
+    condition = alltrue([
+      for hub_key, hub in var.hub_virtual_networks :
+      hub.nat_gateway == null ? true : length(coalesce(hub.nat_gateway.ip_configurations, {})) <= 16
+    ])
+    error_message = "The NAT gateway ip_configurations cannot contain more than 16 elements. This is a limitation of Azure NAT Gateway."
+  }
+  validation {
+    condition = alltrue([
+      for hub_key, hub in var.hub_virtual_networks :
+      hub.hub_virtual_network == null ? true : alltrue([
+        for subnet_key, subnet in coalesce(hub.hub_virtual_network.subnets, {}) :
+        subnet.route_table == null ? true : (
+          subnet.route_table.route_table_reference_key == null ? true : contains(
+            ["Firewall", "UserSubnets"],
+            subnet.route_table.route_table_reference_key
+          )
+        )
+      ])
+    ])
+    error_message = "The subnet route_table_reference_key must be either 'Firewall' or 'UserSubnets'."
+  }
+  validation {
+    condition = alltrue([
+      for hub_key, hub in var.hub_virtual_networks :
+      hub.hub_virtual_network == null ? true : alltrue([
+        for subnet_key, subnet in coalesce(hub.hub_virtual_network.subnets, {}) :
+        subnet.route_table == null ? true : (
+          try(subnet.route_table.route_table_reference_key, "UserSubnets") != "Firewall" ||
+          try(hub.hub_virtual_network.route_table_firewall_enabled, true)
+        )
+      ])
+    ])
+    error_message = "When route_table_reference_key is 'Firewall', hub_virtual_network.route_table_firewall_enabled must be true."
+  }
 }
+

--- a/templates/platform_landing_zone/variables.connectivity.virtual.wan.tf
+++ b/templates/platform_landing_zone/variables.connectivity.virtual.wan.tf
@@ -62,6 +62,13 @@ variable "virtual_hubs" {
       routing_weight = optional(number)
     })), {})
 
+    bgp_connections = optional(map(object({
+      name                          = string
+      peer_asn                      = number
+      peer_ip                       = string
+      virtual_network_connection_id = optional(string)
+    })), {})
+
     p2s_gateway_vpn_server_configurations = optional(map(object({
       name                     = string
       vpn_authentication_types = list(string)
@@ -508,6 +515,7 @@ The following top level attributes are supported:
 - `hub` - (Optional) An object defining the Virtual WAN hub settings.
 - `virtual_network_connections` - (Optional) A map of Virtual Network connections to create.
 - `express_route_circuit_connections` - (Optional) A map of ExpressRoute circuit connections
+- `bgp_connections` - (Optional) A map of BGP connections to create on the Virtual Hub router (for direct NVA peering).
 - `p2s_gateway_vpn_server_configurations` - (Optional) A map of Point-to-Site VPN server configurations.
 - `p2s_gateways` - (Optional) A map of Point-to-Site
 - `routing_intents` - (Optional) A map of routing intents to create.
@@ -558,6 +566,14 @@ The following top level attributes are supported:
   - `express_route_gateway_bypass_enabled` - (Optional) Should ExpressRoute gateway bypass be enabled?
   - `routing` - (Optional) An object with the same fields as virtual_network_connections routing.
   - `routing_weight` - (Optional) The routing weight for the connection.
+
+## BGP Connections
+
+- `bgp_connections` - (Optional) A map of BGP connections to create on the Virtual Hub's built-in router. This is the documented Microsoft pattern for peering Network Virtual Appliances (NVAs) such as Palo Alto, FortiGate or Cisco SD-WAN deployed in spoke virtual networks directly with the Virtual Hub. Each connection is an object with the following fields:
+  - `name` - (Required) The name of the BGP connection.
+  - `peer_asn` - (Required) The peer ASN of the NVA. Must not be `65515` (the Azure-assigned vHub ASN) or any other reserved value documented for Virtual WAN.
+  - `peer_ip` - (Required) The peer IP address of the NVA.
+  - `virtual_network_connection_id` - (Optional) The resource ID of the Virtual Network Connection (`azurerm_virtual_hub_connection`) for the spoke virtual network hosting the NVA. This is recommended when the NVA is reachable through a hub virtual network connection.
 
 ## Point-to-Site Gateway VPN Server Configurations
 
@@ -972,4 +988,14 @@ The shared settings for the hub and spoke networks. This is where global resourc
   - `tags` - (Optional) A map of tags to apply to the DDoS protection plan resource.
 
 DESCRIPTION
+
+  validation {
+    condition = (
+      var.virtual_wan_settings == null
+      || var.virtual_wan_settings.virtual_wan == null
+      || var.virtual_wan_settings.virtual_wan.id == null
+      || can(provider::azapi::parse_resource_id("Microsoft.Network/virtualWans", var.virtual_wan_settings.virtual_wan.id).name)
+    )
+    error_message = "If provided, virtual_wan_settings.virtual_wan.id must be a valid Virtual WAN resource ID of the form /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/virtualWans/<name>."
+  }
 }


### PR DESCRIPTION
## Summary

Bump the connectivity AVM pattern modules to their latest releases and sync the accelerator's variable and output interfaces.

| Module | From | To |
| --- | --- | --- |
| `Azure/avm-ptn-alz-connectivity-hub-and-spoke-vnet/azurerm` | `0.16.14` | `0.17.1` |
| `Azure/avm-ptn-alz-connectivity-virtual-wan/azurerm` | `0.14.0` | `0.15.0` |

## Changes

### Module versions

- `templates/platform_landing_zone/main.connectivity.hub.and.spoke.virtual.network.tf` — bumped to `0.17.1`.
- `templates/platform_landing_zone/main.connectivity.virtual.wan.tf` — bumped to `0.15.0`.

### Variable schemas

Synced `templates/platform_landing_zone/variables.connectivity.hub.and.spoke.virtual.network.tf` to the upstream v0.17.1 schema, exposing:

- `enabled_resources.nat_gateway` toggle and full `nat_gateway` block (SKU, IP configurations, lock, zones)
- `firewall.firewall_subnet_nat_gateway` association
- Per-subnet `nat_gateway` and `route_table.route_table_reference_key` (Firewall / UserSubnets)
- All resource-name override fields (`virtual_network_name`, `firewall_name`, `nat_gateway_name`, `bastion_host_name`, etc.)
- `route_table_name_firewall` / `route_table_name_user_subnets`
- New validation rules (NAT gateway constraints, route table reference key constraint)

Synced `templates/platform_landing_zone/variables.connectivity.virtual.wan.tf` to the upstream v0.15.0 schema, exposing:

- `bgp_connections` map for NVA BGP peering (the headline 0.15.0 feature) and `virtual_network_connection_id`
- All resource-name override fields (`virtual_wan_name`, `virtual_hub_name`, `firewall_name`, `bastion_host_name`, `ddos_protection_plan_name`, etc.)

The accelerator's `optional(any, …)` weakening pattern on enabled-resource flags is preserved (12 fields in H&S, 10 fields in vWAN) so users can still pass truthy values from YAML configuration.

### Outputs

Added new accelerator-level passthrough outputs in `templates/platform_landing_zone/outputs.tf`:

**Hub & spoke**
- `hub_and_spoke_vnet_route_tables_gateway_resource_ids`
- `hub_and_spoke_vnet_ddos_protection_plan_resource_id`
- `hub_and_spoke_vnet_nat_gateway_resource_ids` / `hub_and_spoke_vnet_nat_gateways`
- `hub_and_spoke_vnet_virtual_network_gateway_resource_ids`
- `hub_and_spoke_vnet_virtual_network_gateway_public_ip_addresses` / `_public_ip_resource_ids`
- `hub_and_spoke_vnet_virtual_network_gateway_local_network_gateway_resource_ids` / `_connection_resource_ids`
- `hub_and_spoke_vnet_virtual_network_gateway_express_route_circuit_connection_resource_ids`
- `hub_and_spoke_vnet_bastion_host_public_ip_resource_ids`
- `hub_and_spoke_vnet_dns_resolver_resource_ids` / `_inbound_endpoint_ip_addresses`
- `hub_and_spoke_vnet_private_dns_zone_resource_ids` / `_auto_registration_resource_ids`
- `hub_and_spoke_vnet_private_link_private_dns_zones_maps`

**Virtual WAN**
- `virtual_wan_virtual_hub_bgp_connection_resource_ids`
- `virtual_wan_express_route_gateway_resources`
- `virtual_wan_private_dns_zone_resource_ids`
- `virtual_wan_private_link_private_dns_zones_maps`

## Validation

- `terraform fmt -check` passes.

## Notes

- `outputs.moved.tf` still references the legacy `private_link_private_dns_zone_virtual_network_link_moved_block_template_module_prefix` output, which the upstream modules no longer emit at v0.17.1 / v0.15.0. This output may need to be updated or removed as part of v17 release notes / migration handling — out of scope for this PR.
