### PR TITLE
fix(examples): align tfvars with management_*_enabled toggles

### DIFF
--- a/templates/platform_landing_zone/examples/full-multi-region-nva/hub-and-spoke-vnet.tfvars
+++ b/templates/platform_landing_zone/examples/full-multi-region-nva/hub-and-spoke-vnet.tfvars
@@ -171,8 +171,9 @@ tags = {
 --- Management Resources ---
 You can use this section to customize the management resources that will be deployed.
 */
+management_resources_enabled = true
+
 management_resource_settings = {
-  enabled                      = true
   location                     = "$${starter_location_01}"
   log_analytics_workspace_name = "$${log_analytics_workspace_name}"
   resource_group_name          = "$${management_resource_group_name}"
@@ -199,13 +200,14 @@ management_resource_settings = {
 You can use this section to customize the management groups and policies that will be deployed.
 You can further configure management groups and policy by supplying a `lib` folder. This is detailed in the Accelerator documentation.
 */
+management_groups_enabled = true
+
 management_group_settings = {
   # This is the name of the architecture that will be used to deploy the management resources.
   # It refers to the alz_custom.alz_architecture_definition.yaml file in the lib folder.
   # Do not change this value unless you have created another architecture definition
   # with the name value specified below.
   architecture_name  = "alz_custom"
-  enabled            = true
   location           = "$${starter_location_01}"
   parent_resource_id = "$${root_parent_management_group_id}"
   policy_default_values = {

--- a/templates/platform_landing_zone/examples/full-multi-region-nva/virtual-wan.tfvars
+++ b/templates/platform_landing_zone/examples/full-multi-region-nva/virtual-wan.tfvars
@@ -163,8 +163,9 @@ tags = {
 --- Management Resources ---
 You can use this section to customize the management resources that will be deployed.
 */
+management_resources_enabled = true
+
 management_resource_settings = {
-  enabled                      = true
   location                     = "$${starter_location_01}"
   log_analytics_workspace_name = "$${log_analytics_workspace_name}"
   resource_group_name          = "$${management_resource_group_name}"
@@ -191,13 +192,14 @@ management_resource_settings = {
 You can use this section to customize the management groups and policies that will be deployed.
 You can further configure management groups and policy by supplying a `lib` folder. This is detailed in the Accelerator documentation.
 */
+management_groups_enabled = true
+
 management_group_settings = {
   # This is the name of the architecture that will be used to deploy the management resources.
   # It refers to the alz_custom.alz_architecture_definition.yaml file in the lib folder.
   # Do not change this value unless you have created another architecture definition
   # with the name value specified below.
   architecture_name  = "alz_custom"
-  enabled            = true
   location           = "$${starter_location_01}"
   parent_resource_id = "$${root_parent_management_group_id}"
   policy_default_values = {

--- a/templates/platform_landing_zone/examples/full-multi-region/hub-and-spoke-vnet-minimal.tfvars
+++ b/templates/platform_landing_zone/examples/full-multi-region/hub-and-spoke-vnet-minimal.tfvars
@@ -130,8 +130,9 @@ tags = {
 --- Management Resources ---
 You can use this section to customize the management resources that will be deployed.
 */
+management_resources_enabled = true
+
 management_resource_settings = {
-  enabled                      = true
   location                     = "$${starter_location_01}"
   log_analytics_workspace_name = "$${log_analytics_workspace_name}"
   resource_group_name          = "$${management_resource_group_name}"
@@ -158,8 +159,9 @@ management_resource_settings = {
 You can use this section to customize the management groups and policies that will be deployed.
 You can further configure management groups and policy by supplying a `lib` folder. This is detailed in the Accelerator documentation.
 */
+management_groups_enabled = true
+
 management_group_settings = {
-  enabled = true
   # This is the name of the architecture that will be used to deploy the management resources.
   # It refers to the alz_custom.alz_architecture_definition.yaml file in the lib folder.
   # Do not change this value unless you have created another architecture definition

--- a/templates/platform_landing_zone/examples/full-multi-region/hub-and-spoke-vnet.tfvars
+++ b/templates/platform_landing_zone/examples/full-multi-region/hub-and-spoke-vnet.tfvars
@@ -183,8 +183,9 @@ tags = {
 --- Management Resources ---
 You can use this section to customize the management resources that will be deployed.
 */
+management_resources_enabled = true
+
 management_resource_settings = {
-  enabled                      = true
   location                     = "$${starter_location_01}"
   log_analytics_workspace_name = "$${log_analytics_workspace_name}"
   resource_group_name          = "$${management_resource_group_name}"
@@ -211,8 +212,9 @@ management_resource_settings = {
 You can use this section to customize the management groups and policies that will be deployed.
 You can further configure management groups and policy by supplying a `lib` folder. This is detailed in the Accelerator documentation.
 */
+management_groups_enabled = true
+
 management_group_settings = {
-  enabled = true
   # This is the name of the architecture that will be used to deploy the management resources.
   # It refers to the alz_custom.alz_architecture_definition.yaml file in the lib folder.
   # Do not change this value unless you have created another architecture definition

--- a/templates/platform_landing_zone/examples/full-multi-region/virtual-wan-minimal.tfvars
+++ b/templates/platform_landing_zone/examples/full-multi-region/virtual-wan-minimal.tfvars
@@ -130,8 +130,9 @@ tags = {
 --- Management Resources ---
 You can use this section to customize the management resources that will be deployed.
 */
+management_resources_enabled = true
+
 management_resource_settings = {
-  enabled                      = true
   location                     = "$${starter_location_01}"
   log_analytics_workspace_name = "$${log_analytics_workspace_name}"
   resource_group_name          = "$${management_resource_group_name}"
@@ -158,8 +159,9 @@ management_resource_settings = {
 You can use this section to customize the management groups and policies that will be deployed.
 You can further configure management groups and policy by supplying a `lib` folder. This is detailed in the Accelerator documentation.
 */
+management_groups_enabled = true
+
 management_group_settings = {
-  enabled = true
   # This is the name of the architecture that will be used to deploy the management resources.
   # It refers to the alz_custom.alz_architecture_definition.yaml file in the lib folder.
   # Do not change this value unless you have created another architecture definition

--- a/templates/platform_landing_zone/examples/full-multi-region/virtual-wan.tfvars
+++ b/templates/platform_landing_zone/examples/full-multi-region/virtual-wan.tfvars
@@ -164,8 +164,9 @@ tags = {
 --- Management Resources ---
 You can use this section to customize the management resources that will be deployed.
 */
+management_resources_enabled = true
+
 management_resource_settings = {
-  enabled                      = true
   location                     = "$${starter_location_01}"
   log_analytics_workspace_name = "$${log_analytics_workspace_name}"
   resource_group_name          = "$${management_resource_group_name}"
@@ -192,8 +193,9 @@ management_resource_settings = {
 You can use this section to customize the management groups and policies that will be deployed.
 You can further configure management groups and policy by supplying a `lib` folder. This is detailed in the Accelerator documentation.
 */
+management_groups_enabled = true
+
 management_group_settings = {
-  enabled = true
   # This is the name of the architecture that will be used to deploy the management resources.
   # It refers to the alz_custom.alz_architecture_definition.yaml file in the lib folder.
   # Do not change this value unless you have created another architecture definition

--- a/templates/platform_landing_zone/examples/full-single-region-nva/hub-and-spoke-vnet.tfvars
+++ b/templates/platform_landing_zone/examples/full-single-region-nva/hub-and-spoke-vnet.tfvars
@@ -133,8 +133,9 @@ tags = {
 --- Management Resources ---
 You can use this section to customize the management resources that will be deployed.
 */
+management_resources_enabled = true
+
 management_resource_settings = {
-  enabled                      = true
   location                     = "$${starter_location_01}"
   log_analytics_workspace_name = "$${log_analytics_workspace_name}"
   resource_group_name          = "$${management_resource_group_name}"
@@ -161,8 +162,9 @@ management_resource_settings = {
 You can use this section to customize the management groups and policies that will be deployed.
 You can further configure management groups and policy by supplying a `lib` folder. This is detailed in the Accelerator documentation.
 */
+management_groups_enabled = true
+
 management_group_settings = {
-  enabled = true
   # This is the name of the architecture that will be used to deploy the management resources.
   # It refers to the alz_custom.alz_architecture_definition.yaml file in the lib folder.
   # Do not change this value unless you have created another architecture definition

--- a/templates/platform_landing_zone/examples/full-single-region-nva/virtual-wan.tfvars
+++ b/templates/platform_landing_zone/examples/full-single-region-nva/virtual-wan.tfvars
@@ -129,8 +129,9 @@ tags = {
 --- Management Resources ---
 You can use this section to customize the management resources that will be deployed.
 */
+management_resources_enabled = true
+
 management_resource_settings = {
-  enabled                      = true
   location                     = "$${starter_location_01}"
   log_analytics_workspace_name = "$${log_analytics_workspace_name}"
   resource_group_name          = "$${management_resource_group_name}"
@@ -157,8 +158,9 @@ management_resource_settings = {
 You can use this section to customize the management groups and policies that will be deployed.
 You can further configure management groups and policy by supplying a `lib` folder. This is detailed in the Accelerator documentation.
 */
+management_groups_enabled = true
+
 management_group_settings = {
-  enabled = true
   # This is the name of the architecture that will be used to deploy the management resources.
   # It refers to the alz_custom.alz_architecture_definition.yaml file in the lib folder.
   # Do not change this value unless you have created another architecture definition

--- a/templates/platform_landing_zone/examples/full-single-region/hub-and-spoke-vnet.tfvars
+++ b/templates/platform_landing_zone/examples/full-single-region/hub-and-spoke-vnet.tfvars
@@ -139,8 +139,9 @@ tags = {
 --- Management Resources ---
 You can use this section to customize the management resources that will be deployed.
 */
+management_resources_enabled = true
+
 management_resource_settings = {
-  enabled                      = true
   location                     = "$${starter_location_01}"
   log_analytics_workspace_name = "$${log_analytics_workspace_name}"
   resource_group_name          = "$${management_resource_group_name}"
@@ -167,8 +168,9 @@ management_resource_settings = {
 You can use this section to customize the management groups and policies that will be deployed.
 You can further configure management groups and policy by supplying a `lib` folder. This is detailed in the Accelerator documentation.
 */
+management_groups_enabled = true
+
 management_group_settings = {
-  enable_telemetry = true
   # This is the name of the architecture that will be used to deploy the management resources.
   # It refers to the alz_custom.alz_architecture_definition.yaml file in the lib folder.
   # Do not change this value unless you have created another architecture definition

--- a/templates/platform_landing_zone/examples/full-single-region/virtual-wan.tfvars
+++ b/templates/platform_landing_zone/examples/full-single-region/virtual-wan.tfvars
@@ -130,8 +130,9 @@ tags = {
 --- Management Resources ---
 You can use this section to customize the management resources that will be deployed.
 */
+management_resources_enabled = true
+
 management_resource_settings = {
-  enabled                      = true
   location                     = "$${starter_location_01}"
   log_analytics_workspace_name = "$${log_analytics_workspace_name}"
   resource_group_name          = "$${management_resource_group_name}"
@@ -158,8 +159,9 @@ management_resource_settings = {
 You can use this section to customize the management groups and policies that will be deployed.
 You can further configure management groups and policy by supplying a `lib` folder. This is detailed in the Accelerator documentation.
 */
+management_groups_enabled = true
+
 management_group_settings = {
-  enabled = true
   # This is the name of the architecture that will be used to deploy the management resources.
   # It refers to the alz_custom.alz_architecture_definition.yaml file in the lib folder.
   # Do not change this value unless you have created another architecture definition

--- a/templates/platform_landing_zone/examples/management-only/management.tfvars
+++ b/templates/platform_landing_zone/examples/management-only/management.tfvars
@@ -86,8 +86,9 @@ tags = {
 --- Management Resources ---
 You can use this section to customize the management resources that will be deployed.
 */
+management_resources_enabled = true
+
 management_resource_settings = {
-  enabled                      = true
   location                     = "$${starter_location_01}"
   log_analytics_workspace_name = "$${log_analytics_workspace_name}"
   resource_group_name          = "$${management_resource_group_name}"
@@ -114,8 +115,9 @@ management_resource_settings = {
 You can use this section to customize the management groups and policies that will be deployed.
 You can further configure management groups and policy by supplying a `lib` folder. This is detailed in the Accelerator documentation.
 */
+management_groups_enabled = true
+
 management_group_settings = {
-  enabled = true
   # This is the name of the architecture that will be used to deploy the management resources.
   # It refers to the alz_custom.alz_architecture_definition.yaml file in the lib folder.
   # Do not change this value unless you have created another architecture definition

--- a/templates/platform_landing_zone/examples/migration/hub-and-spoke-vnet.tfvars
+++ b/templates/platform_landing_zone/examples/migration/hub-and-spoke-vnet.tfvars
@@ -183,8 +183,9 @@ tags = { # MIGRATION: This had a different default in CAF ES.
 --- Management Resources ---
 You can use this section to customize the management resources that will be deployed.
 */
+management_resources_enabled = true
+
 management_resource_settings = {
-  enabled                                   = true
   location                                  = "$${starter_location_01}"
   log_analytics_workspace_name              = "$${log_analytics_workspace_name}"
   log_analytics_workspace_retention_in_days = 60 # MIGRATION: This had a different default in CAF ES.
@@ -216,8 +217,9 @@ management_resource_settings = {
 You can use this section to customize the management groups and policies that will be deployed.
 You can further configure management groups and policy by supplying a `lib` folder. This is detailed in the Accelerator documentation.
 */
+management_groups_enabled = false # MIGRATION: This is off by design to allow migrating connectivity first. You'll turn it on when you migrate management groups and policy.
+
 management_group_settings = {
-  enabled = false # MIGRATION: This is off by design to allow migrating connectivity first. You'll turn it on when you migrate management groups and policy.
   # This is the name of the architecture that will be used to deploy the management resources.
   # It refers to the alz_custom.alz_architecture_definition.yaml file in the lib folder.
   # Do not change this value unless you have created another architecture definition

--- a/templates/platform_landing_zone/examples/migration/lib/architecture_definitions/alz_custom.alz_architecture_definition.yaml
+++ b/templates/platform_landing_zone/examples/migration/lib/architecture_definitions/alz_custom.alz_architecture_definition.yaml
@@ -31,6 +31,12 @@ management_groups:
     id: alz-online-example-2
     parent_id: alz-landing-zones
   - archetypes:
+      - local_custom
+    display_name: ALZ Local
+    exists: false
+    id: alz-local
+    parent_id: alz-landing-zones
+  - archetypes:
       - sandbox_custom
     display_name: Sandboxes
     exists: false

--- a/templates/platform_landing_zone/examples/migration/lib/architecture_definitions/alz_custom.alz_architecture_definition.yaml
+++ b/templates/platform_landing_zone/examples/migration/lib/architecture_definitions/alz_custom.alz_architecture_definition.yaml
@@ -32,9 +32,9 @@ management_groups:
     parent_id: alz-landing-zones
   - archetypes:
       - local_custom
-    display_name: ALZ Local
+    display_name: Local
     exists: false
-    id: alz-local
+    id: local
     parent_id: alz-landing-zones
   - archetypes:
       - sandbox_custom

--- a/templates/platform_landing_zone/examples/migration/virtual-wan.tfvars
+++ b/templates/platform_landing_zone/examples/migration/virtual-wan.tfvars
@@ -165,8 +165,9 @@ tags = { # MIGRATION: This had a different default in CAF ES.
 --- Management Resources ---
 You can use this section to customize the management resources that will be deployed.
 */
+management_resources_enabled = true
+
 management_resource_settings = {
-  enabled                                   = true
   location                                  = "$${starter_location_01}"
   log_analytics_workspace_name              = "$${log_analytics_workspace_name}"
   log_analytics_workspace_retention_in_days = 60 # MIGRATION: This had a different default in CAF ES.
@@ -198,8 +199,9 @@ management_resource_settings = {
 You can use this section to customize the management groups and policies that will be deployed.
 You can further configure management groups and policy by supplying a `lib` folder. This is detailed in the Accelerator documentation.
 */
+management_groups_enabled = false # MIGRATION: This is off by design to allow migrating connectivity first. You'll turn it on when you migrate management groups and policy.
+
 management_group_settings = {
-  enabled = true
   # This is the name of the architecture that will be used to deploy the management resources.
   # It refers to the alz_custom.alz_architecture_definition.yaml file in the lib folder.
   # Do not change this value unless you have created another architecture definition

--- a/templates/platform_landing_zone/examples/smb-single-region/hub-and-spoke-vnet.tfvars
+++ b/templates/platform_landing_zone/examples/smb-single-region/hub-and-spoke-vnet.tfvars
@@ -121,8 +121,9 @@ tags = {
 --- Management Resources ---
 You can use this section to customize the management resources that will be deployed.
 */
+management_resources_enabled = true
+
 management_resource_settings = {
-  enabled                      = true
   location                     = "$${starter_location_01}"
   log_analytics_workspace_name = "$${log_analytics_workspace_name}"
   resource_group_name          = "$${management_resource_group_name}"
@@ -149,8 +150,9 @@ management_resource_settings = {
 You can use this section to customize the management groups and policies that will be deployed.
 You can further configure management groups and policy by supplying a `lib` folder. This is detailed in the Accelerator documentation.
 */
+management_groups_enabled = true
+
 management_group_settings = {
-  enabled = true
   # This is the name of the architecture that will be used to deploy the management resources.
   # It refers to the alz_custom.alz_architecture_definition.yaml file in the lib folder.
   # Do not change this value unless you have created another architecture definition

--- a/templates/platform_landing_zone/examples/smb-single-region/virtual-wan.tfvars
+++ b/templates/platform_landing_zone/examples/smb-single-region/virtual-wan.tfvars
@@ -123,8 +123,9 @@ tags = {
 --- Management Resources ---
 You can use this section to customize the management resources that will be deployed.
 */
+management_resources_enabled = true
+
 management_resource_settings = {
-  enabled                      = true
   location                     = "$${starter_location_01}"
   log_analytics_workspace_name = "$${log_analytics_workspace_name}"
   resource_group_name          = "$${management_resource_group_name}"
@@ -151,8 +152,9 @@ management_resource_settings = {
 You can use this section to customize the management groups and policies that will be deployed.
 You can further configure management groups and policy by supplying a `lib` folder. This is detailed in the Accelerator documentation.
 */
+management_groups_enabled = true
+
 management_group_settings = {
-  enabled = true
   # This is the name of the architecture that will be used to deploy the management resources.
   # It refers to the alz_custom.alz_architecture_definition.yaml file in the lib folder.
   # Do not change this value unless you have created another architecture definition


### PR DESCRIPTION
## Summary

Fixes: https://github.com/Azure/Azure-Landing-Zones/issues/4154

Align all example `.tfvars` files under `templates/platform_landing_zone/examples/` with the strict object schemas of `management_resource_settings` and `management_group_settings`, and with the separate top-level toggle variables `management_resources_enabled` and `management_groups_enabled`.

## Why

Both `management_resource_settings` and `management_group_settings` are declared as strict `object({...})` types in `templates/platform_landing_zone/variables.management.tf`. Neither type declares a top-level `enabled` (or `enable_telemetry`) field. The enable/disable toggles are separate top-level bool variables that gate the corresponding modules via `count = var.X_enabled ? 1 : 0` in `main.management.groups.tf` and `main.management.resources.tf`.

Several example tfvars carried an invalid top-level `enabled = true` inside one or both of those blocks (and one carried `enable_telemetry = true`), which would be rejected by the strict object type.

## Changes

For every example tfvars file:

- Removed invalid top-level `enabled` / `enable_telemetry` from inside `management_resource_settings = {}` and `management_group_settings = {}`.
- Added explicit top-level `management_resources_enabled = true`.
- Added explicit top-level `management_groups_enabled`:
  - `false` (with a MIGRATION comment explaining the staged cut-over) in both `examples/migration/*.tfvars`.
  - `true` in all other examples.

Files affected (15 tracked; `examples/test/test.tfvars` is also updated locally but is gitignored):

- `full-multi-region/{hub-and-spoke-vnet,hub-and-spoke-vnet-minimal,virtual-wan,virtual-wan-minimal}.tfvars`
- `full-multi-region-nva/{hub-and-spoke-vnet,virtual-wan}.tfvars`
- `full-single-region/{hub-and-spoke-vnet,virtual-wan}.tfvars`
- `full-single-region-nva/{hub-and-spoke-vnet,virtual-wan}.tfvars`
- `management-only/management.tfvars`
- `migration/{hub-and-spoke-vnet,virtual-wan}.tfvars` (toggle = `false`)
- `smb-single-region/{hub-and-spoke-vnet,virtual-wan}.tfvars`

## Verification

- Static scan: zero remaining `enabled` / `enable_telemetry` lines inside any top-level `management_resource_settings` or `management_group_settings` block across all 16 example tfvars; exactly one `management_resources_enabled` and one `management_groups_enabled` per file with the expected values.
- Runtime: `terraform console` against the migration and full-single-region tfvars confirms both toggles resolve to the expected booleans, `try(var.management_resource_settings.enabled, "ABSENT")` returns `"ABSENT"`, and no schema/type errors are raised against the four variables involved.
