### PR TITLE
feat(platform): upgrade avm-ptn-alz and expose resource_types

### DIFF
--- a/templates/platform_landing_zone/examples/migration/hub-and-spoke-vnet.tfvars
+++ b/templates/platform_landing_zone/examples/migration/hub-and-spoke-vnet.tfvars
@@ -293,6 +293,27 @@ management_group_settings = {
     }
   }
   */
+
+  # MIGRATION: Override the `role_definition` resource type to use the `RoleDefinitions` (capital `R`) casing.
+  # This works around the AzAPI casing inconsistency reported in
+  # https://github.com/Azure/Azure-Landing-Zones/issues/4165, which causes
+  # `Provider produced inconsistent result after apply` and `Unexpected Identity Change`
+  # errors on custom role definitions in migrated environments.
+  # If you do not have pre-existing custom role definitions you can remove this block.
+  resource_types = {
+    role_definition = "Microsoft.Authorization/RoleDefinitions@2022-04-01"
+
+    # Other keys you can override (defaults shown). Useful for sovereign clouds
+    # (e.g. US Government) that require different API versions:
+    # management_group              = "Microsoft.Management/managementGroups@2023-04-01"
+    # management_group_settings     = "Microsoft.Management/managementGroups/settings@2023-04-01"
+    # management_group_subscription = "Microsoft.Management/managementGroups/subscriptions@2023-04-01"
+    # policy_assignment             = "Microsoft.Authorization/policyAssignments@2024-04-01"
+    # policy_definition             = "Microsoft.Authorization/policyDefinitions@2023-04-01"
+    # policy_set_definition         = "Microsoft.Authorization/policySetDefinitions@2023-04-01"
+    # role_assignment               = "Microsoft.Authorization/roleAssignments@2022-04-01"
+    # user_assigned_identity        = "Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31"
+  }
 }
 
 /*

--- a/templates/platform_landing_zone/examples/migration/virtual-wan.tfvars
+++ b/templates/platform_landing_zone/examples/migration/virtual-wan.tfvars
@@ -275,6 +275,27 @@ management_group_settings = {
     }
   }
   */
+
+  # MIGRATION: Override the `role_definition` resource type to use the `RoleDefinitions` (capital `R`) casing.
+  # This works around the AzAPI casing inconsistency reported in
+  # https://github.com/Azure/Azure-Landing-Zones/issues/4165, which causes
+  # `Provider produced inconsistent result after apply` and `Unexpected Identity Change`
+  # errors on custom role definitions in migrated environments.
+  # If you do not have pre-existing custom role definitions you can remove this block.
+  resource_types = {
+    role_definition = "Microsoft.Authorization/RoleDefinitions@2022-04-01"
+
+    # Other keys you can override (defaults shown). Useful for sovereign clouds
+    # (e.g. US Government) that require different API versions:
+    # management_group              = "Microsoft.Management/managementGroups@2023-04-01"
+    # management_group_settings     = "Microsoft.Management/managementGroups/settings@2023-04-01"
+    # management_group_subscription = "Microsoft.Management/managementGroups/subscriptions@2023-04-01"
+    # policy_assignment             = "Microsoft.Authorization/policyAssignments@2024-04-01"
+    # policy_definition             = "Microsoft.Authorization/policyDefinitions@2023-04-01"
+    # policy_set_definition         = "Microsoft.Authorization/policySetDefinitions@2023-04-01"
+    # role_assignment               = "Microsoft.Authorization/roleAssignments@2022-04-01"
+    # user_assigned_identity        = "Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31"
+  }
 }
 
 /*

--- a/templates/platform_landing_zone/locals.tf
+++ b/templates/platform_landing_zone/locals.tf
@@ -33,6 +33,7 @@ locals {
       identity                = try(policy_assignment_value.identity, null)
       identity_ids            = try(policy_assignment_value.identity_ids, null)
       parameters              = try({ for parameter_key, parameter_value in try(policy_assignment_value.parameters, {}) : parameter_key => jsonencode({ value = parameter_value }) }, null)
+      not_scopes              = try(policy_assignment_value.not_scopes, null)
       non_compliance_messages = try(policy_assignment_value.non_compliance_messages, null)
       resource_selectors      = try(policy_assignment_value.resource_selectors, null)
       overrides               = try(policy_assignment_value.overrides, null)

--- a/templates/platform_landing_zone/main.management.groups.tf
+++ b/templates/platform_landing_zone/main.management.groups.tf
@@ -1,6 +1,6 @@
 module "management_groups" {
   source  = "Azure/avm-ptn-alz/azurerm"
-  version = "0.19.1"
+  version = "0.21.0"
   count   = var.management_groups_enabled ? 1 : 0
 
   architecture_name                                                = module.config.outputs.management_group_settings.architecture_name
@@ -21,6 +21,7 @@ module "management_groups" {
   role_assignment_name_use_random_uuid                             = module.config.outputs.management_group_settings.role_assignment_name_use_random_uuid
   subscription_placement_destroy_behavior                          = module.config.outputs.management_group_settings.subscription_placement_destroy_behavior
   subscription_placement_destroy_custom_target_management_group_id = module.config.outputs.management_group_settings.subscription_placement_destroy_custom_target_management_group_id
+  resource_types                                                   = module.config.outputs.management_group_settings.resource_types
   policy_assignments_dependencies                                  = local.management_group_dependencies
   policy_role_assignments_dependencies                             = local.management_group_dependencies
   telemetry_additional_content                                     = var.telemetry_additional_content

--- a/templates/platform_landing_zone/terraform.tf
+++ b/templates/platform_landing_zone/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     alz = {
       source  = "Azure/alz"
-      version = "0.20.2"
+      version = "~> 0.21"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/templates/platform_landing_zone/variables.management.tf
+++ b/templates/platform_landing_zone/variables.management.tf
@@ -280,16 +280,23 @@ variable "management_group_settings" {
     })))
     role_assignment_definition_lookup_enabled = optional(bool, true)
     policy_assignment_non_compliance_message_settings = optional(object({
-      fallback_message_enabled                 = optional(bool)
-      fallback_message                         = optional(string)
-      fallback_message_unsupported_assignments = optional(list(string))
-      enforcement_mode_placeholder             = optional(string)
-      enforced_replacement                     = optional(string)
-      not_enforced_replacement                 = optional(string)
+      default_message = optional(string)
+      merge_mode      = optional(string)
     }))
     role_assignment_name_use_random_uuid                             = optional(bool, true)
     subscription_placement_destroy_behavior                          = optional(string, "intermediate_root")
     subscription_placement_destroy_custom_target_management_group_id = optional(string)
+    resource_types = optional(object({
+      management_group              = optional(string)
+      management_group_settings     = optional(string)
+      management_group_subscription = optional(string)
+      policy_assignment             = optional(string)
+      policy_definition             = optional(string)
+      policy_set_definition         = optional(string)
+      role_assignment               = optional(string)
+      role_definition               = optional(string)
+      user_assigned_identity        = optional(string)
+    }))
   })
   default     = null
   description = <<DESCRIPTION
@@ -306,6 +313,7 @@ Properties:
     - `identity` - (Optional) The type of managed identity for the policy assignment.
     - `identity_ids` - (Optional) List of user-assigned identity resource IDs.
     - `parameters` - (Optional) Map of parameter values for the policy assignment.
+    - `not_scopes` - (Optional) List of resource IDs to exclude from the policy assignment scope.
     - `non_compliance_messages` - (Optional) Set of non-compliance messages:
       - `message` - (Required) The non-compliance message.
       - `policy_definition_reference_id` - (Optional) The policy definition reference ID.
@@ -363,16 +371,22 @@ Properties:
   - `delegated_managed_identity_resource_id` - (Optional) The delegated managed identity resource ID.
   - `principal_type` - (Optional) The type of principal.
 - `role_assignment_definition_lookup_enabled` - (Optional) Enable role definition lookup for assignments. Defaults to true.
-- `policy_assignment_non_compliance_message_settings` - (Optional) Settings for policy non-compliance messages:
-  - `fallback_message_enabled` - (Optional) Enable fallback messages.
-  - `fallback_message` - (Optional) The fallback message text.
-  - `fallback_message_unsupported_assignments` - (Optional) List of unsupported assignment names.
-  - `enforcement_mode_placeholder` - (Optional) Placeholder for enforcement mode.
-  - `enforced_replacement` - (Optional) Replacement text for enforced mode.
-  - `not_enforced_replacement` - (Optional) Replacement text for not enforced mode.
+- `policy_assignment_non_compliance_message_settings` - (Optional) Settings for the default non-compliance messages applied to policy assignments by the `alz` provider:
+  - `default_message` - (Optional) The default non-compliance message to apply to policy assignments. Supports placeholder substitution configured in the provider's `non_compliance_message_substitution_settings` block.
+  - `merge_mode` - (Optional) Controls behavior when a policy assignment already has a default non-compliance message. Allowed values are `replace` (default) and `prefer_existing`.
 - `role_assignment_name_use_random_uuid` - (Optional) Use random UUID for role assignment names. Defaults to true.
 - `subscription_placement_destroy_behavior` - (Optional) The behavior for subscription placement on destroy. Defaults to "intermediate_root" for ALZ.
 - `subscription_placement_destroy_custom_target_management_group_id` - (Optional) The target management group ID for subscription placement destroy operations.
+- `resource_types` - (Optional) A map of full AzAPI resource type strings (`<provider>/<resource>@<api-version>`) used by the module. Override an entry to change the casing or API version of the corresponding resource type. Useful for sovereign clouds (e.g. US Government) or to work around AzAPI casing inconsistencies. Keys:
+  - `management_group`
+  - `management_group_settings`
+  - `management_group_subscription`
+  - `policy_assignment`
+  - `policy_definition`
+  - `policy_set_definition`
+  - `role_assignment`
+  - `role_definition`
+  - `user_assigned_identity`
 
 Details of the settings can be found in the module documentation at https://registry.terraform.io/modules/Azure/avm-ptn-alz
 DESCRIPTION

--- a/templates/test/main.tf
+++ b/templates/test/main.tf
@@ -6,7 +6,7 @@ locals {
 
 module "management_groups" {
   source                                  = "Azure/avm-ptn-alz/azurerm"
-  version                                 = "0.19.1"
+  version                                 = "0.21.0"
   architecture_name                       = "alz_custom"
   parent_resource_id                      = var.root_parent_management_group_id == "" ? data.azurerm_client_config.current.tenant_id : var.root_parent_management_group_id
   location                                = local.starter_location

--- a/templates/test/terraform.tf
+++ b/templates/test/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     alz = {
       source  = "Azure/alz"
-      version = "0.20.2"
+      version = "~> 0.21"
     }
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
## Summary
Upgrade the platform landing zone templates to `Azure/avm-ptn-alz/azurerm` `0.21.0` and `Azure/alz` `~> 0.21`, and add support for the new `resource_types` input.

## Changes
- bump `avm-ptn-alz` to `0.21.0` in the platform and test templates
- bump `Azure/alz` to `~> 0.21` in the platform and test templates
- add `resource_types` to `management_group_settings`
- align `policy_assignment_non_compliance_message_settings` with the updated upstream input shape
- wire `not_scopes` through `policy_assignments_to_modify`
- add migration example `resource_types` overrides showing the workaround for Azure-Landing-Zones issue `#4165`

## Validation
- `terraform init -upgrade -backend=false -input=false` in `templates/platform_landing_zone`
- `terraform validate` in `templates/platform_landing_zone`
- `terraform init -upgrade -backend=false -input=false` in `templates/test`
- `terraform validate` in `templates/test`