### PR TITLE
docs: fix nat_gateway Defaults ´false´

### DIFF
--- a/templates/platform_landing_zone/variables.connectivity.hub.and.spoke.virtual.network.tf
+++ b/templates/platform_landing_zone/variables.connectivity.hub.and.spoke.virtual.network.tf
@@ -727,7 +727,7 @@ The following top level attributes are supported:
     - `virtual_network_gateway_vpn` - (Optional) Should the VPN gateway be created? Default `true`.
     - `private_dns_zones` - (Optional) Should private DNS zones be created? Default `true`.
     - `private_dns_resolver` - (Optional) Should the private DNS resolver be created? Default `true`.
-    - `nat_gateway` - (Optional) Should the NAT Gateway be created? Default `true`.
+    - `nat_gateway` - (Optional) Should the NAT Gateway be created? Default `false`.
   - `default_hub_address_space` - (Optional) The default address space to use if not specified in hub_virtual_network. This defaults to `10.0.0.0/16` and increments to the next /16 for each region if not supplied.
   - `default_parent_id` - (Optional) The default parent resource group ID to use if not specified in hub_virtual_network or individual sections.
   - `location` - (Required) The Azure location where the hub network resources should be created.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

See here the default is `false` and not `true`, this is a documentation update only

https://github.com/Azure/alz-terraform-accelerator/blob/248966ae03d2bad712fd974a7b1d7164f474fcca/templates/platform_landing_zone/variables.connectivity.hub.and.spoke.virtual.network.tf#L41



## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
