### PR TITLE
feat(platform): filter subscription placement by valid GUIDs

### DIFF
--- a/templates/platform_landing_zone/locals.tf
+++ b/templates/platform_landing_zone/locals.tf
@@ -55,3 +55,11 @@ locals {
     local.connectivity_virtual_wan_enabled ? module.virtual_wan : null
   ]
 }
+
+locals {
+  # Remove keys if subscription_id is not a valid GUID, i.e. null or empty string
+  subscription_placement_filtered = {
+    for k, v in module.config.outputs.management_group_settings.subscription_placement : k => v
+    if can(regex("^[a-f\\d]{4}(?:[a-f\\d]{4}-){4}[a-f\\d]{12}$", v.subscription_id))
+  }
+}

--- a/templates/platform_landing_zone/main.management.groups.tf
+++ b/templates/platform_landing_zone/main.management.groups.tf
@@ -11,7 +11,7 @@ module "management_groups" {
   enable_telemetry                                                 = var.enable_telemetry
   management_group_hierarchy_settings                              = module.config.outputs.management_group_settings.management_group_hierarchy_settings
   retries                                                          = module.config.outputs.management_group_settings.retries
-  subscription_placement                                           = module.config.outputs.management_group_settings.subscription_placement
+  subscription_placement                                           = local.subscription_placement_filtered
   timeouts                                                         = module.config.outputs.management_group_settings.timeouts
   override_policy_definition_parameter_assign_permissions_set      = module.config.outputs.management_group_settings.override_policy_definition_parameter_assign_permissions_set
   override_policy_definition_parameter_assign_permissions_unset    = module.config.outputs.management_group_settings.override_policy_definition_parameter_assign_permissions_unset


### PR DESCRIPTION
## Overview/Summary

This pull request introduces a validation step to ensure that only valid subscription IDs are passed to the `management_groups` module. The main improvement is filtering out entries with invalid or empty subscription IDs before passing them along, which helps prevent errors and enforces data integrity.

**Subscription placement validation:**

* Added a new local value `subscription_placement_filtered` in `locals.tf` that filters out entries from `subscription_placement` where the `subscription_id` is not a valid GUID.
* Updated `main.management.groups.tf` to use the filtered `local.subscription_placement_filtered` instead of the unfiltered `subscription_placement` when passing data to the `management_groups` module.

## This PR fixes

1. Fixes Azure/Azure-Landing-Zones#4239

### Breaking Changes

1. N/A

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

<img width="1988" height="1332" alt="image" src="https://github.com/user-attachments/assets/c947b3d3-68d3-4deb-9c98-536e3aae7048" />

Using the Management Only starter. I also successfully ran the workflow with the Destroy action.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.