### PR TITLE
feat: expose route_tables on virtual_hubs (#4193)

### DIFF
--- a/templates/platform_landing_zone/main.connectivity.virtual.wan.tf
+++ b/templates/platform_landing_zone/main.connectivity.virtual.wan.tf
@@ -1,6 +1,6 @@
 module "virtual_wan" {
   source  = "Azure/avm-ptn-alz-connectivity-virtual-wan/azurerm"
-  version = "0.16.1"
+  version = "0.17.2"
 
   count = local.connectivity_virtual_wan_enabled ? 1 : 0
 

--- a/templates/platform_landing_zone/variables.connectivity.virtual.wan.tf
+++ b/templates/platform_landing_zone/variables.connectivity.virtual.wan.tf
@@ -42,6 +42,23 @@ variable "virtual_hubs" {
       }))
     })), {})
 
+    route_tables = optional(map(object({
+      name   = string
+      labels = optional(list(string))
+      # `{}` default required: this attribute is forwarded to the pattern module's `route_tables.*.routes`,
+      # which is consumed directly by a submodule `dynamic` block's for_each. Terraform cannot iterate `null`,
+      # and an explicit default here (not just on the pattern module) is required because a caller-omitted
+      # attribute becomes an explicit `null` once it passes through this variable's own type conversion.
+      routes = optional(map(object({
+        name                = string
+        destinations        = list(string)
+        destinations_type   = string
+        next_hop            = optional(string)
+        vnet_connection_key = optional(string)
+        next_hop_type       = optional(string, "ResourceId")
+      })), {})
+    })), {})
+
     express_route_circuit_connections = optional(map(object({
       name                                 = string
       express_route_circuit_peering_id     = string


### PR DESCRIPTION
## Overview/Summary

Exposes Virtual WAN hub route table support (`route_tables`) on the `virtual_hubs` variable in this repo's `platform_landing_zone` template, so Accelerator-generated deployments can configure `azurerm_virtual_hub_route_table` resources. This consumes the schema added to the pattern module in [terraform-azurerm-avm-ptn-alz-connectivity-virtual-wan#130](https://github.com/Azure/terraform-azurerm-avm-ptn-alz-connectivity-virtual-wan/pull/130), now released as `v0.17.2`.

## This PR fixes/adds/changes/removes

1. Adds a `route_tables` optional map to the `virtual_hubs` object in `templates/platform_landing_zone/variables.connectivity.virtual.wan.tf`, matching the pattern module's schema 1:1.
2. Adds a `{}` default on the nested `routes` attribute. This is required independently at this layer: `optional(type, default)` only rescues an attribute the caller omits entirely - once a value passes through this variable's own type conversion, an omitted `routes` attribute becomes an explicit `null`, which the pattern module's own default cannot see through. Without this default here, a route table declared with labels only would fail with `Invalid dynamic for_each value ... each.value.routes is null`, even after the pattern module fix ships.
3. Bumps the pattern module pin in `templates/platform_landing_zone/main.connectivity.virtual.wan.tf` from `0.16.1` to `0.17.2`.

### Why the version bump is required, not cosmetic

Terraform **silently drops** object attributes that are absent from the target module's type constraint. Against the previous `0.16.1` pin, a user could set `route_tables` in their YAML, pass Accelerator validation, and have it deploy **nothing at all with no error raised** - a silent no-op. Items 1 and 2 are only meaningful together with item 3.

No other file in this repo references the module version, so this single pin is the complete change.

### Breaking Changes

None. The schema change is purely additive (`optional(..., {})`), so existing deployments are unaffected. The module bump moves from `0.16.1` to `0.17.2`; see the [release notes](https://github.com/Azure/terraform-azurerm-avm-ptn-alz-connectivity-virtual-wan/releases/tag/v0.17.2), which contain only additive changes plus a lifecycle-hook fix.

## Dependency - now satisfied

This PR was opened as a draft pending the companion pattern module work. All three preconditions are now met:

1. ~~PR #130 must merge on the pattern module repo~~ - **merged** (commit `4b82077`).
2. ~~A new registry release containing that merge must be published~~ - **released as [`v0.17.2`](https://github.com/Azure/terraform-azurerm-avm-ptn-alz-connectivity-virtual-wan/releases/tag/v0.17.2)** and indexed on the Terraform Registry.
3. ~~This branch must add a version-bump commit~~ - **added** in this branch's latest commit.

Marking ready for review.

## Testing Evidence

- `terraform init` on `templates/platform_landing_zone` against the updated pin resolves the new release from the registry: `Downloading registry.terraform.io/Azure/avm-ptn-alz-connectivity-virtual-wan/azurerm 0.17.2 for virtual_wan...` -> `Terraform has been successfully initialized!`
- `terraform validate` -> `Success! The configuration is valid.`
- `terraform fmt -check` - clean (the pin change is length-neutral, so alignment is unaffected).
- Confirmed the resolved `0.17.2` module in `.terraform/modules/virtual_wan/variables.tf` exposes `route_tables` with a shape matching this template's schema 1:1, so no attribute is dropped at the module boundary.
- Passthrough verified end to end: `virtual_hubs` reaches `module.config` inside an `inputs` block typed `any` (no re-typing, nothing dropped in transit), and `route_tables` is nested within `virtual_hubs` and flattened inside the pattern module - so unlike `route_maps`, no additional flattening local is needed in this repo.
- Full-chain proof from the original draft: an isolated copy of the rendered Accelerator output with this schema synced in, fresh `terraform init` + `terraform plan` against a `route_tables` test scenario - resolves both a routed table (via `vnet_connection_key`) and a labels-only table with no `routes` attribute, `Plan: 590 to add, 0 to change, 0 to destroy`, zero errors.

## As part of this Pull Request I have

- [x] Checked for duplicate Pull Requests
- [x] Associated it with relevant issues, for tracking and closure - related to Azure/Azure-Landing-Zones#4193
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` branch
- [x] Performed testing and provided evidence
- [x] Updated relevant and associated documentation - the `virtual_hubs` schema is self-documenting via its type constraint and inline comments; no separate docs in this repo reference the Virtual WAN interface
